### PR TITLE
ALS-3916: Upgrade jenkins version

### DIFF
--- a/initial-configuration/jenkins/jenkins-docker/Dockerfile
+++ b/initial-configuration/jenkins/jenkins-docker/Dockerfile
@@ -32,4 +32,4 @@ RUN apt-get install jq -y
 
 RUN apt-get -y install uuid-runtime
 
-RUN jenkins-plugin-cli < /usr/share/jenkins/ref/plugins.txt || echo "Some errors occurred during plugin installation."
+RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt


### PR DESCRIPTION
* Update jenkins version to latest, 2.377
* `install-plugins.sh` was removed in favor of `jenkins-plugin-cli`
* This resolves issues running groovy scripts due to mismatched versions of the groovy plugin and the script security plugin, described here: https://stackoverflow.com/questions/57495765/jenkins-pipeline-fails-after-upgrade-sandboxtransformer-forbidiffinalizer