### PR TITLE
Update RedHat install script for automated initial configuration

### DIFF
--- a/initial-configuration/jenkins/jenkins-docker/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/config.xml
@@ -176,7 +176,7 @@
           <string>project_specific_override_repo</string>
           <string>__PROJECT_SPECIFIC_OVERRIDE_REPO__</string>
           <string>release_control_branch</string>
-          <string>feature/redhat</string>
+          <string>*/master</string>
           <string>release_control_repo</string>
           <string>__RELEASE_CONTROL_REPO__</string>
         </tree-map>

--- a/initial-configuration/jenkins/jenkins-docker/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/config.xml
@@ -176,7 +176,7 @@
           <string>project_specific_override_repo</string>
           <string>__PROJECT_SPECIFIC_OVERRIDE_REPO__</string>
           <string>release_control_branch</string>
-          <string>*/master</string>
+          <string>*/main</string>
           <string>release_control_repo</string>
           <string>__RELEASE_CONTROL_REPO__</string>
         </tree-map>

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -64,7 +64,6 @@ docker run -it --rm  --name test2 --network=picsure hello-world
 docker run -it --rm  --name test3 --network=hpdsNet hello-world
 
 setenforce 0
-systemctl restart firewalld
 firewall-cmd --add-port=8080/tcp
 firewall-cmd --runtime-to-permanent
 podman network reload --all

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -63,8 +63,7 @@ docker run -it --rm  --name test1 --network=podman hello-world
 docker run -it --rm  --name test2 --network=picsure hello-world
 docker run -it --rm  --name test3 --network=hpdsNet hello-world
 
-systemctl daemon-reload
-service firewalld restart
+systemctl restart firewalld
 firewall-cmd --add-port=8080/tcp
 firewall-cmd --runtime-to-permanent
 podman network reload --all

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -59,7 +59,7 @@ docker network inspect picsure --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker ne
 docker network inspect hpdsNet --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create hpdsNet
 
 systemctl stop firewalld
-firewall-cmd --permanent --add-port=8080/tcp
+firewall-offline-cmd --permanent --add-port=8080/tcp
 systemctl start firewalld
 podman network reload --all
 firewall-cmd --reload

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -63,12 +63,14 @@ docker run -it --rm  --name test1 --network=podman hello-world
 docker run -it --rm  --name test2 --network=picsure hello-world
 docker run -it --rm  --name test3 --network=hpdsNet hello-world
 
+setenforce 0
 systemctl restart firewalld
 firewall-cmd --add-port=8080/tcp
 firewall-cmd --runtime-to-permanent
 podman network reload --all
 firewall-cmd --reload
 systemctl daemon-reload
+setenforce 1
 
 ##Installing Configuring MariaDB/Mysql configuration
 

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -63,6 +63,7 @@ docker run -it --rm  --name test1 --network=podman hello-world
 docker run -it --rm  --name test2 --network=picsure hello-world
 docker run -it --rm  --name test3 --network=hpdsNet hello-world
 
+systemctl daemon-reload
 service firewalld restart
 firewall-cmd --add-port=8080/tcp
 firewall-cmd --runtime-to-permanent

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -85,7 +85,7 @@ systemctl enable --now mariadb.service
 systemctl start mariadb.service
 
 echo "` < /dev/urandom tr -dc @^=+$*%_A-Z-a-z-0-9 | head -c${1:-24}`%4cA" > pass.tmp
-mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('`cat pass.tmp`');flush privileges;"
+mysql -u root --connect-expired-password -e "ALTER USER root@localhost IDENTIFIED BY '`cat pass.tmp`';flush privileges;"
 
 echo "[mysql]" > ~/.my.cnf
 echo "user = root" >> ~/.my.cnf

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -24,8 +24,8 @@ yum clean -y  packages
 ## Installing and starting Firewalld service 
 
 yum install firewalld -y
-systemctl start firewalld
 systemctl enable --now firewalld
+systemctl start firewalld
 
 ##Instaling Maven
 
@@ -63,7 +63,7 @@ docker run -it --rm  --name test1 --network=podman hello-world
 docker run -it --rm  --name test2 --network=picsure hello-world
 docker run -it --rm  --name test3 --network=hpdsNet hello-world
 
-systemctl start firewalld
+service firewalld restart
 firewall-cmd --add-port=8080/tcp
 firewall-cmd --runtime-to-permanent
 podman network reload --all

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -58,9 +58,9 @@ docker network inspect podman --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker net
 docker network inspect picsure --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create picsure
 docker network inspect hpdsNet --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create hpdsNet
 
-systemctl stop firewalld
-firewall-offline-cmd --permanent --add-port=8080/tcp
 systemctl start firewalld
+firewall-cmd --add-port=8080/tcp
+firewall-cmd --runtime-to-permanent
 podman network reload --all
 firewall-cmd --reload
 systemctl daemon-reload

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -34,8 +34,9 @@ wget https://www.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3
 tar -xvzf /opt/apache-maven-3.6.3-bin.tar.gz -C /opt
 rm -rf /opt/apache-maven-3.6.3-bin.tar.gz
 
-##Installing continer tools, podman services to build and run containers.
+## Emulating Docker CLI using podman.
 
+# Installing continer tools, podman services to build and run containers.
 echo "install container-tools podman podman-docker podman-plugins"
 dnf module reset -y container-tools
 dnf module install -y container-tools:4.0
@@ -43,8 +44,12 @@ yum install -y podman-docker podman-plugins
 yum install -y podman-compose-0.1.7
 echo "Finished podman install, enabling and starting podman required service"
 
-echo "alias docker=podman" >> ~/.bash_profile
-source ~/.bash_profile
+# Symlink docker to podman so we can emultate system wide.
+# Sometimes, ~/.bash_profile nor ~/.bashrc aliases were getting sourced in jenkins shell processes.
+ln -s "$(which podman)" /bin/docker
+
+# Create /etc/containers/nodocker to quiet msg.
+mkdir -p /etc/containers/nodocker
 
 ## Creating Podman networks 
 
@@ -53,18 +58,16 @@ docker network inspect podman --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker net
 docker network inspect picsure --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create picsure
 docker network inspect hpdsNet --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create hpdsNet
 
-#podman network create podman
-#podman network create picsure
-#podman network create hpdsNet
-
-docker run -it --rm hello-world
-docker run -it --rm  --name test1 --network=picsure hello-world
-docker run -it --rm  --name test2 --network=hpdsNet hello-world && docker rmi hello-world
-firewall-cmd --add-port=8080/tcp
+firewall-offline-cmd --add-port=8080/tcp
 firewall-cmd --runtime-to-permanent
 podman network reload --all
 firewall-cmd --reload
 systemctl daemon-reload
+
+# Run docker using networks to ensure their network interface is up and can be added to the mysql database by interface ip
+docker run -it --rm  --name test1 --network=podman hello-world
+docker run -it --rm  --name test2 --network=picsure hello-world
+docker run -it --rm  --name test3 --network=hpdsNet hello-world
 
 ##Installing Configuring MariaDB/Mysql configuration
 
@@ -76,26 +79,21 @@ echo "[mysqld]" >> /etc/my.cnf
 echo "bind-address=0.0.0.0" >> /etc/my.cnf
 echo "default-time-zone='-00:00'" >> /etc/my.cnf
 
-systemctl enable --now  mariadb.service
+systemctl enable --now mariadb.service
 systemctl start mariadb.service
 
 echo "` < /dev/urandom tr -dc @^=+$*%_A-Z-a-z-0-9 | head -c${1:-24}`%4cA" > pass.tmp
-mysql -u root --connect-expired-password -e "ALTER USER root@localhost IDENTIFIED BY '`cat pass.tmp`';flush privileges;"
+mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('`cat pass.tmp`');flush privileges;"
 
 echo "[mysql]" > ~/.my.cnf
 echo "user = root" >> ~/.my.cnf
 echo "password = `cat pass.tmp`" >> ~/.my.cnf
-#echo "password = `grep "temporary password" /var/log/mysqld.log | cut -d ' ' -f 11`" >> ~/.my.cnf
 echo "port = 3306" >> ~/.my.cnf
 echo "host = 0.0.0.0" >> ~/.my.cnf
-#echo "` < /dev/urandom tr -dc @^=+$*%_A-Z-a-z-0-9 | head -c${1:-24}`%4cA" > pass.tmp
-#mysql -u root --connect-expired-password -e "alter user 'root'@'localhost' identified by '`cat pass.tmp`';flush privileges;"
-#sed -i "s/password = .*/password = \"`cat pass.tmp`\"/g" ~/.my.cnf
 
-for addr in $(ifconfig | grep netmask | sed 's/  */ /g'| cut -d ' ' -f 3);
-do
-newaddr=$(awk -F"." '{print $1"."$2"."$3".%"}'<<<$addr)
- mysql -u root -e "grant all privileges on *.* to 'root'@'$newaddr' identified by '`cat pass.tmp`'  WITH GRANT OPTION;flush privileges;";
+for addr in $(ifconfig | grep netmask | sed 's/  */ /g' | cut -d ' ' -f 3); do
+  newaddr=$(awk -F"." '{print $1"."$2"."$3".%"}' <<< $addr)
+  mysql -u root -e "grant all privileges on *.* to 'root'@'$newaddr' identified by '`cat pass.tmp`'  WITH GRANT OPTION;flush privileges;";
 done
 
 MYSQL_PASSWORD=`cat pass.tmp`
@@ -165,6 +163,7 @@ sed -i 's/jdbc:mysql*.*auth/jdbc:mysql:\/\/'$MYSQL_HOST_NAME':'$MYSQL_PORT'\/aut
 sed -i 's/jdbc:mysql*.*picsure/jdbc:mysql:\/\/'$MYSQL_HOST_NAME':'$MYSQL_PORT'\/picsure/g' /usr/local/docker-config/wildfly/standalone.xml
 cd $CWD
 echo "Mysql/MariaDB setup completed"
+
 ###############################
 echo "Building and installing Jenkins"
 #docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$http_proxy --build-arg no_proxy="$no_proxy" \
@@ -209,25 +208,29 @@ cp plugins.txt /usr/share/jenkins/ref/plugins.txt
 cd $CWD
 echo "Downloading jenkins Plugins"
 #wget https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.12.6/jenkins-plugin-manager-2.12.6.jar
-java -jar $CWD/jenkins-plugin-manager-2.12.6.jar --war /usr/share/jenkins/jenkins.war -d /var/jenkins_home/plugins  --plugin-file $CWD/jenkins/jenkins-docker/plugins.txt --verbose
+java -jar $CWD/jenkins-plugin-manager-2.12.6.jar \
+  --war /usr/share/jenkins/jenkins.war \
+  -d /var/jenkins_home/plugins  \
+  --plugin-file $CWD/jenkins/jenkins-docker/plugins.txt \
+  --verbose
 echo "Starting Jenkins Locally"
 
 systemctl stop jenkins
 systemctl start jenkins
 echo "Jenkins Startup completed checking jenkins process"
-ps -aef|grep jenkins
+ps -aef | grep jenkins
 
 ##########################################################
 
 cd $CWD
 
 export APP_ID=`uuidgen -r`
-export APP_ID_HEX=`echo $APP_ID | awk '{ print toupper($0) }'|sed 's/-//g'`
+export APP_ID_HEX=`echo $APP_ID | awk '{ print toupper($0) }' | sed 's/-//g'`
 sed -i "s/__STACK_SPECIFIC_APPLICATION_ID__/$APP_ID/g" /usr/local/docker-config/httpd/picsureui_settings.json
 sed -i "s/__STACK_SPECIFIC_APPLICATION_ID__/$APP_ID/g" /usr/local/docker-config/wildfly/standalone.xml
 
 export RESOURCE_ID=`uuidgen -r`
-export RESOURCE_ID_HEX=`echo $RESOURCE_ID | awk '{ print toupper($0) }'|sed 's/-//g'`
+export RESOURCE_ID_HEX=`echo $RESOURCE_ID | awk '{ print toupper($0) }' | sed 's/-//g'`
 sed -i "s/__STACK_SPECIFIC_RESOURCE_UUID__/$RESOURCE_ID/g" /usr/local/docker-config/httpd/picsureui_settings.json
 
 echo $APP_ID > /usr/local/docker-config/APP_ID_RAW
@@ -242,5 +245,3 @@ cd /usr/local/docker-config/hpds_csv/
 tar -xvzf allConcepts.csv.tgz
 
 echo "Installation script complete.  Started Jenkins."
-
-#../start-jenkins.sh

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -58,8 +58,9 @@ docker network inspect podman --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker net
 docker network inspect picsure --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create picsure
 docker network inspect hpdsNet --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create hpdsNet
 
-firewall-offline-cmd --add-port=8080/tcp
-firewall-cmd --runtime-to-permanent
+systemctl stop firewalld
+firewall-cmd --permanent --add-port=8080/tcp
+systemctl start firewalld
 podman network reload --all
 firewall-cmd --reload
 systemctl daemon-reload

--- a/initial-configuration/redhat-install-dependencies.sh
+++ b/initial-configuration/redhat-install-dependencies.sh
@@ -58,17 +58,17 @@ docker network inspect podman --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker net
 docker network inspect picsure --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create picsure
 docker network inspect hpdsNet --format "{{.Name}}: {{.Id}}" 2>&1  ||  docker network create hpdsNet
 
+# Run docker using networks to ensure their network interface is up and can be added to the mysql database by interface ip
+docker run -it --rm  --name test1 --network=podman hello-world
+docker run -it --rm  --name test2 --network=picsure hello-world
+docker run -it --rm  --name test3 --network=hpdsNet hello-world
+
 systemctl start firewalld
 firewall-cmd --add-port=8080/tcp
 firewall-cmd --runtime-to-permanent
 podman network reload --all
 firewall-cmd --reload
 systemctl daemon-reload
-
-# Run docker using networks to ensure their network interface is up and can be added to the mysql database by interface ip
-docker run -it --rm  --name test1 --network=podman hello-world
-docker run -it --rm  --name test2 --network=picsure hello-world
-docker run -it --rm  --name test3 --network=hpdsNet hello-world
 
 ##Installing Configuring MariaDB/Mysql configuration
 

--- a/initial-configuration/uninstall.sh
+++ b/initial-configuration/uninstall.sh
@@ -33,7 +33,7 @@ rm -f /root/configure_docker_networking.sh
 
 # MySQL
 systemctl stop mysqld
-yum -y remove mysql-community-server mysql-community-client mysql-community-release
+yum -y remove mysql-community-server mysql-community-client mysql-community-release mariadb-server
 rm -f /etc/my.cnf
 rm -f ~/.my.cnf
 rm -rf /var/lib/mysql


### PR DESCRIPTION
- Add comments about obscure operations.
- Move nodocker directory commend to suppress podman as docker meulation message.
- selinux was blocking the firewalld command being run from the script, but it worked on manual invocation. To solve, we're placing selinux into permissive mode and returning after configurations.
- Update password set for root to use suggested method.
- Add mariadb uninstall to uninstall script to reset database.
- Reset branch name for project_specific_override_repo to master branch.