### PR TITLE
ALS-4780: Update maven install to use apt-get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .project
+*.iml

--- a/initial-configuration/jenkins/jenkins-docker/Dockerfile
+++ b/initial-configuration/jenkins/jenkins-docker/Dockerfile
@@ -14,8 +14,6 @@ RUN echo deb http://archive.debian.org/debian stretch-backports main >> /etc/apt
 
 RUN apt-get update
 
-RUN apt-get -y install apt-transport-https wget
-
 RUN curl -fsSL https://get.docker.com | sh
 
 RUN docker --version

--- a/initial-configuration/jenkins/jenkins-docker/Dockerfile
+++ b/initial-configuration/jenkins/jenkins-docker/Dockerfile
@@ -20,13 +20,9 @@ RUN curl -fsSL https://get.docker.com | sh
 
 RUN docker --version
 
-RUN wget https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.2/apache-maven-3.9.2-bin.tar.gz -P /opt
+RUN apt-get -y install maven
 
 RUN apt-get -y -t stretch-backports install openjdk-11-jdk-headless
-
-RUN tar -xvzf /opt/apache-maven-3.9.2-bin.tar.gz -C /opt
-
-RUN rm /opt/apache-maven-3.9.2-bin.tar.gz
 
 RUN apt-get install jq -y
 

--- a/initial-configuration/jenkins/jenkins-docker/Dockerfile
+++ b/initial-configuration/jenkins/jenkins-docker/Dockerfile
@@ -20,9 +20,9 @@ RUN curl -fsSL https://get.docker.com | sh
 
 RUN docker --version
 
-RUN apt-get -y install maven
-
 RUN apt-get -y -t stretch-backports install openjdk-11-jdk-headless
+
+RUN apt-get -y install maven
 
 RUN apt-get install jq -y
 

--- a/initial-configuration/jenkins/jenkins-docker/hudson.tasks.Maven.xml
+++ b/initial-configuration/jenkins/jenkins-docker/hudson.tasks.Maven.xml
@@ -2,8 +2,8 @@
 <hudson.tasks.Maven_-DescriptorImpl>
   <installations>
     <hudson.tasks.Maven_-MavenInstallation>
-      <name>Maven 3.9.2</name>
-      <home>/opt/apache-maven-3.9.2/</home>
+      <name>Maven Home</name>
+      <home>/usr/share/maven/</home>
       <properties/>
     </hudson.tasks.Maven_-MavenInstallation>
   </installations>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure JupyterHub Token Introspection Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure JupyterHub Token Introspection Token/config.xml
@@ -29,7 +29,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean install</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure PIC-SURE Token Introspection Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure PIC-SURE Token Introspection Token/config.xml
@@ -29,7 +29,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean install</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE Aggregate Resource/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE Aggregate Resource/config.xml
@@ -64,7 +64,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean package -DskipTests -Dwildfly.skip=true</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE PassThrough Resource/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE PassThrough Resource/config.xml
@@ -76,7 +76,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean package -DskipTests -Dwildfly.skip=true</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Auth Micro-App Build/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Auth Micro-App Build/config.xml
@@ -46,7 +46,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean install -DskipTests</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE-API Build/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE-API Build/config.xml
@@ -46,7 +46,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean install -DskipTests -Dwildfly.skip=true</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE-HPDS Build/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE-HPDS Build/config.xml
@@ -46,7 +46,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean install -DskipTests</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE-HPDS-UI Docker Build/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE-HPDS-UI Docker Build/config.xml
@@ -46,7 +46,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean install -DskipTests</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Update User Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Update User Token/config.xml
@@ -46,7 +46,7 @@
   <builders>
     <hudson.tasks.Maven>
       <targets>clean install</targets>
-      <mavenName>Maven 3.9.2</mavenName>
+      <mavenName>Maven Home</mavenName>
       <usePrivateRepository>false</usePrivateRepository>
       <settings class="jenkins.mvn.DefaultSettingsProvider"/>
       <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>


### PR DESCRIPTION
* Also updates jenkins configs to point to `/usr/share/maven/` where maven will always be installed now