### PR TITLE
Fix Jenkins Dockerfile

### DIFF
--- a/initial-configuration/jenkins/jenkins-docker/Dockerfile
+++ b/initial-configuration/jenkins/jenkins-docker/Dockerfile
@@ -18,8 +18,6 @@ RUN curl -fsSL https://get.docker.com | sh
 
 RUN docker --version
 
-RUN apt-get -y -t stretch-backports install openjdk-11-jdk-headless
-
 RUN apt-get -y install maven
 
 RUN apt-get install jq -y

--- a/initial-configuration/jenkins/jenkins-docker/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/config.xml
@@ -169,13 +169,15 @@
           <default>
             <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../../../../views/listView/jobNames/comparator"/>
           </default>
-          <int>3</int>
+          <int>4</int>
           <string>project_specific_override_repo</string>
           <string>__PROJECT_SPECIFIC_OVERRIDE_REPO__</string>
           <string>release_control_branch</string>
           <string>*/master</string>
           <string>release_control_repo</string>
           <string>__RELEASE_CONTROL_REPO__</string>
+          <string>JAVA_HOME</string>
+          <string>/opt/java/openjdk</string>
         </tree-map>
       </envVars>
     </hudson.slaves.EnvironmentVariablesNodeProperty>


### PR DESCRIPTION
The jenkins image comes with both JDK 11 and 17 installed. Despite this, we have, historically, installed JDK 11 _again_. This started breaking, which makes a lot of sense.

I deleted the extra JDK install step and set up the JAVA_HOME var in the Jenkins config.