### PR TITLE
[ALS-5213] Add new job for banner

### DIFF
--- a/initial-configuration/config/httpd/banner_config.json
+++ b/initial-configuration/config/httpd/banner_config.json
@@ -1,0 +1,13 @@
+{
+  "bannerConfiguration": [
+    {
+      "text": "<p>A test banner</p>",
+      "startDate": "2023-11-13T13:00:00Z",
+      "endDate": "2024-11-13T16:00:00Z",
+      "styles": "background-color: #0000FF; color: #fff; font-size: 1.1em; padding: 10px;",
+      "class": "",
+      "isDismissible": true,
+      "disabled": true
+    }
+  ]
+}

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Update Banner Configuration/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Update Banner Configuration/config.xml
@@ -1,0 +1,36 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description>
+        This job is used to update the banner_config.json file on the Jenkins server.
+        The file is used by the Jenkins Docker container to display the banner on the website.
+    </description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <hudson.model.ParametersDefinitionProperty>
+            <parameterDefinitions>
+                <hudson.model.FileParameterDefinition>
+                    <name>banner_config.json</name>
+                    <description>Upload the banner_config.json file</description>
+                </hudson.model.FileParameterDefinition>
+            </parameterDefinitions>
+        </hudson.model.ParametersDefinitionProperty>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>#!/bin/bash
+                # Replace /usr/local/docker-config with the actual path where you want to copy the file
+                cp "${WORKSPACE}/banner_config.json" /usr/local/docker-config/httpd/banner_config.json
+            </command>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers/>
+    <buildWrappers/>
+</project>

--- a/start-picsure.sh
+++ b/start-picsure.sh
@@ -14,6 +14,7 @@ fi
 export WILDFLY_JAVA_OPTS="-Xms2g -Xmx4g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true $PROXY_OPTS"
 export HPDS_OPTS="-XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms1g -Xmx16g -DCACHE_SIZE=1500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=$EXPORT_SIZE -DALL_IDS_CONCEPT=NONE -DID_CUBE_NAME=NONE -Denable_file_sharing=true"
 export PICSURE_SETTINGS_VOLUME="-v /usr/local/docker-config/httpd/picsureui_settings.json:/usr/local/apache2/htdocs/picsureui/settings/settings.json"
+export PICSURE_BANNER_VOLUME="-v /usr/local/docker-config/httpd/banner_config.json:/usr/local/apache2/htdocs/picsureui/settings/banner_config.json"
 export PSAMA_SETTINGS_VOLUME="-v /usr/local/docker-config/httpd/psamaui_settings.json:/usr/local/apache2/htdocs/picsureui/psamaui/settings/settings.json"
 export EMAIL_TEMPLATE_VOUME="-v /usr/local/docker-config/wildfly/emailTemplates:/opt/jboss/wildfly/standalone/configuration/emailTemplates "
 
@@ -44,6 +45,7 @@ docker stop httpd && docker rm httpd
 docker run --name=httpd --restart always --network=picsure \
   -v /var/log/httpd-docker-logs/:/usr/local/apache2/logs/ \
   $PICSURE_SETTINGS_VOLUME \
+  $PICSURE_BANNER_VOLUME \
   $PSAMA_SETTINGS_VOLUME \
   -v /usr/local/docker-config/httpd/cert:/usr/local/apache2/cert/ \
   $CUSTOM_HTTPD_VOLUMES \


### PR DESCRIPTION
- Adding a new Jenkins job that can be used to add or replace the banner_config.json. This allows all-in-one users to change the banner without a full redeployment.
- Minor update to banner_config.json and the update banner job. I needed to wrap the first portion of the CP in quotes. This is because there are white spaces in the path.
- Mount the banner_config.json file to HTTPD
- Including a test banner that is disabled by default.