### PR TITLE
[ALS-4422] Create root certs in trust store

### DIFF
--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Root Certs in TrustStore/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Root Certs in TrustStore/config.xml
@@ -1,0 +1,28 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Downloads and imports LetsEncrypt root certs to trust store.</description>
+  <keepDependencies>false</keepDependencies>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>
+        <!--Download certs-->
+        curl https://letsencrypt.org/certs/isrgrootx1.der -o isrgrootx1.der
+        curl https://letsencrypt.org/certs/lets-encrypt-r3.der -o lets-encrypt-r3.der
+
+        <!--Import Certs to trust store-->
+        keytool -import -keystore /usr/local/docker-config/wildfly/application.truststore -storepass password -noprompt -trustcacerts -alias letsencryptauthority1 -file isrgrootx1.der
+        keytool -import -keystore /usr/local/docker-config/wildfly/application.truststore -storepass password -noprompt -trustcacerts -alias letsencryptauthority2 -file lets-encrypt-r3.der
+      </command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Initial Configuration Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Initial Configuration Pipeline/config.xml
@@ -105,6 +105,11 @@ pipeline {
                                 [$class: &apos;StringParameterValue&apos;, name: &apos;AUTH0_CLIENT_SECRET&apos;, value: env.AUTH0_CLIENT_SECRET]]
                         }
                     },
+                    addRootCerts: {
+                        script {
+                            def result = build job: &apos;Create Root Certs in TrustStore&apos;
+                        }
+                    },
 		    emailConfig: {
                         script {
                             def result = build job: &apos;Configure Outbound Email Settings&apos;, parameters: [


### PR DESCRIPTION
- If we trust letsencrypt's root certs, we can follow that chain of authority and trust auth0 things more easily
- Create a job to do this
- Add that job to the initial pipeline