### PR TITLE
[ALS-7065] All-In-One PSAMA initial configuration environment file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .project
 *.iml
 initial-configuration/mysql-docker/.env
+pass.tmp
+initial-configuration/pass.tmp

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ you exact instructions. If you're following the legacy install instructions, you
 `cd pic-sure-all-in-one/initial-configuration`
 Choose one of the following use cases:
 - *Fully dockerized install.* Our current happy path.
-`sudo ./install-dependencies-docker.sh /path/to/desired/config/dir/ && source ~/.bashrc`
+`sudo ./install-dependencies-docker.sh /path/to/desired/config/dir/ /path/to/desired/mysql/cnf/dir && source ~/.bashrc`
 - *Legacy install.* I know what I'm doing. `sudo ./install-dependencies.sh`
 - *Jenkins on https.* This is rare:
 ```shell
@@ -131,6 +131,7 @@ Once you have logged into Jenkins and have set up your admin account, you need t
 system variables:
 
 - `DOCKER_CONFIG_DIR`: `/path/to/config/dir` This is the path you passed to `install-dependencies-docker`
+- `MYSQL_CONFIG_DIR`: `/path/to/mysql/cnf/dir` This is the path you passed to `install-dependencies-docker`
 - `MYSQL_NETWORK`: `picsure` If you plan to switch to a remote database, this needs to be changed back to `host`
 
 6. Run the Initial Configuration Pipeline job.

--- a/initial-configuration/install-dependencies-docker.sh
+++ b/initial-configuration/install-dependencies-docker.sh
@@ -46,7 +46,7 @@ function set_docker_config_dir {
 function set_mysql_config_dir() {
   local mysql_config_dir=$1
   if [ -z "$mysql_config_dir" ]; then
-    mysql_config_dir="/root"
+    mysql_config_dir="$DOCKER_CONFIG_DIR/picsure-db/"
   fi
   #Check if mysql_config_dir is a dir and exists
   if [ ! -d "$mysql_config_dir" ]; then

--- a/initial-configuration/install-dependencies-docker.sh
+++ b/initial-configuration/install-dependencies-docker.sh
@@ -89,7 +89,7 @@ if [ -n "$(command -v apt-get)" ] && [ -z "$(command -v docker)" ]; then
 fi
 
 if [[ "$OSTYPE" =~ ^darwin ]]; then
-    echo "Darwin detected. Assuming macOS. Install commands will use brew." 
+    echo "Darwin detected. Assuming macOS. Install commands will use brew."
     #check for brew
     if [ -z "$(command -v brew)" ]; then
       echo "Brew not detected. Please install brew and rerun this script."
@@ -111,7 +111,7 @@ fi
 if [ -n "$(command -v apk)" ]; then
   echo "apk detected. Assuming alpine. Install commands will use apk"
   apk update && apk add --no-cache wget
-fi 
+fi
 
 if [ -z "$(command -v docker)" ]; then
   echo "You dont have docker installed and we cant detect a supported package manager."
@@ -171,10 +171,12 @@ export APP_ID=`uuidgen | tr '[:upper:]' '[:lower:]'`
 export APP_ID_HEX=`echo $APP_ID | awk '{ print toupper($0) }'|sed 's/-//g'`
 sed_inplace "s/__STACK_SPECIFIC_APPLICATION_ID__/$APP_ID/g" $DOCKER_CONFIG_DIR/httpd/picsureui_settings.json
 sed_inplace "s/__STACK_SPECIFIC_APPLICATION_ID__/$APP_ID/g" $DOCKER_CONFIG_DIR/wildfly/standalone.xml
+sed_inplace "s/__STACK_SPECIFIC_APPLICATION_ID__/$APP_ID/g" $DOCKER_CONFIG_DIR/psama/.env
 
 export RESOURCE_ID=`uuidgen | tr '[:upper:]' '[:lower:]'`
 export RESOURCE_ID_HEX=`echo $RESOURCE_ID | awk '{ print toupper($0) }'|sed 's/-//g'`
 sed_inplace "s/__STACK_SPECIFIC_RESOURCE_UUID__/$RESOURCE_ID/g" $DOCKER_CONFIG_DIR/httpd/picsureui_settings.json
+
 
 echo $APP_ID > $DOCKER_CONFIG_DIR/APP_ID_RAW
 echo $APP_ID_HEX > $DOCKER_CONFIG_DIR/APP_ID_HEX

--- a/initial-configuration/install-dependencies-docker.sh
+++ b/initial-configuration/install-dependencies-docker.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 sed_inplace() {
@@ -44,7 +43,28 @@ function set_docker_config_dir {
   echo 'alias picsure-db="docker exec -ti picsure-db bash -c '\''mysql -uroot -p\$MYSQL_ROOT_PASSWORD'\''"' >> "$rc_file"
 }
 
+function set_mysql_config_dir() {
+  local mysql_config_dir=$1
+  if [ -z "$mysql_config_dir" ]; then
+    mysql_config_dir="/root"
+  fi
+  #Check if mysql_config_dir is a dir and exists
+  if [ ! -d "$mysql_config_dir" ]; then
+    echo "Creating dir $mysql_config_dir and setting MYSQL_CONFIG_DIR in $rc_file"
+    mkdir -p $mysql_config_dir
+    export MYSQL_CONFIG_DIR=$mysql_config_dir
+    echo "export MYSQL_CONFIG_DIR=$mysql_config_dir" >> "$rc_file"
+  else
+    echo "dir $mysql_config_dir exists, just setting MYSQL_CONFIG_DIR in $rc_file"
+    # If the config dir exists, we still want to clean up old settings for it
+    export MYSQL_CONFIG_DIR=$1
+    grep 'MYSQL_CONFIG_DIR' "$rc_file" && sed_inplace '/MYSQL_CONFIG_DIR/d' "$rc_file"
+    echo "export MYSQL_CONFIG_DIR=$mysql_config_dir" >> "$rc_file"
+  fi
+}
+
 set_docker_config_dir "$1"
+set_mysql_config_dir "$2"
 
 #-------------------------------------------------------------------------------------------------#
 #                                          Docker Install                                         #
@@ -55,7 +75,7 @@ echo "Starting update"
 echo "Installing docker"
 if [ -n "$(command -v yum)" ] && [ -z "$(command -v docker)" ]; then
   echo "Yum detected. Assuming RHEL. Install commands will use yum"
-  set_docker_config_dir $1  "$HOME/.zshrc"
+  set_docker_config_dir $1 "$HOME/.zshrc"
   yum -y update
   # This repo can be removed after we move away from centos 7 I think
   yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo

--- a/initial-configuration/install-dependencies.sh
+++ b/initial-configuration/install-dependencies.sh
@@ -109,6 +109,7 @@ export APP_ID=`uuidgen -r`
 export APP_ID_HEX=`echo $APP_ID | awk '{ print toupper($0) }'|sed 's/-//g'`
 sed -i "s/__STACK_SPECIFIC_APPLICATION_ID__/$APP_ID/g" /usr/local/docker-config/httpd/picsureui_settings.json
 sed -i "s/__STACK_SPECIFIC_APPLICATION_ID__/$APP_ID/g" /usr/local/docker-config/wildfly/standalone.xml
+sed -i "s/__STACK_SPECIFIC_APPLICATION_ID__/$APP_ID/g" /usr/local/docker-config/psama/.env
 
 export RESOURCE_ID=`uuidgen -r`
 export RESOURCE_ID_HEX=`echo $RESOURCE_ID | awk '{ print toupper($0) }'|sed 's/-//g'`

--- a/initial-configuration/jenkins/jenkins-docker/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/config.xml
@@ -210,7 +210,7 @@
           <string>MYSQL_NETWORK</string>
           <string>host</string>
           <string>MYSQL_CONFIG_DIR</string>
-          <string>/root/</string>
+          <string>/usr/local/docker-config/picsure-db/</string>
         </tree-map>
       </envVars>
     </hudson.slaves.EnvironmentVariablesNodeProperty>

--- a/initial-configuration/jenkins/jenkins-docker/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/config.xml
@@ -196,7 +196,7 @@
           <default>
             <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../../../../views/listView/jobNames/comparator"/>
           </default>
-          <int>6</int>
+          <int>7</int>
           <string>project_specific_override_repo</string>
           <string>__PROJECT_SPECIFIC_OVERRIDE_REPO__</string>
           <string>release_control_branch</string>
@@ -209,6 +209,8 @@
           <string>/usr/local/docker-config/</string>
           <string>MYSQL_NETWORK</string>
           <string>host</string>
+          <string>MYSQL_CONFIG_DIR</string>
+          <string>/root/</string>
         </tree-map>
       </envVars>
     </hudson.slaves.EnvironmentVariablesNodeProperty>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Build and Deploy Microservice/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Build and Deploy Microservice/config.xml
@@ -56,7 +56,7 @@
     <hudson.tasks.Shell>
       <command># Get the resource from the db if it exists
 export SQL=&quot;SELECT LOWER(CONCAT(SUBSTR(HEX(uuid), 1, 8), &apos;-&apos;, SUBSTR(HEX(uuid), 9, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 13, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 17, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 21))) from picsure.resource where name = &apos;$service_name&apos;&quot;;
-export resource_uuid=$(docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
+export resource_uuid=$(docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
 
 # Add the resource to the database if it doesn&apos;t already exist
 if [ -z &quot;$resource_uuid&quot; ]; then
@@ -64,12 +64,12 @@ if [ -z &quot;$resource_uuid&quot; ]; then
     echo &apos;&apos;
 	export SQL=&quot;INSERT IGNORE INTO picsure.resource (uuid, name, resourceRSPath, description) \
 	VALUES (UUID(), &apos;$service_name&apos;, &apos;http://$service_name/&apos;, &apos;$service_description&apos;)&quot;;
-	docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure
+	docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure
 fi
 
 # Get the resource from the db 
 export SQL=&quot;SELECT LOWER(CONCAT(SUBSTR(HEX(uuid), 1, 8), &apos;-&apos;, SUBSTR(HEX(uuid), 9, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 13, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 17, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 21))) from picsure.resource where name = &apos;$service_name&apos;&quot;;
-export resource_uuid=$(docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
+export resource_uuid=$(docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
 echo &apos;&apos;
 echo &quot;Done adding to db. Using $resource_uuid as uuid&quot;; 
 

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Build and Deploy Microservice/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Build and Deploy Microservice/config.xml
@@ -56,7 +56,7 @@
     <hudson.tasks.Shell>
       <command># Get the resource from the db if it exists
 export SQL=&quot;SELECT LOWER(CONCAT(SUBSTR(HEX(uuid), 1, 8), &apos;-&apos;, SUBSTR(HEX(uuid), 9, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 13, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 17, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 21))) from picsure.resource where name = &apos;$service_name&apos;&quot;;
-export resource_uuid=$(docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
+export resource_uuid=$(docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
 
 # Add the resource to the database if it doesn&apos;t already exist
 if [ -z &quot;$resource_uuid&quot; ]; then
@@ -64,12 +64,12 @@ if [ -z &quot;$resource_uuid&quot; ]; then
     echo &apos;&apos;
 	export SQL=&quot;INSERT IGNORE INTO picsure.resource (uuid, name, resourceRSPath, description) \
 	VALUES (UUID(), &apos;$service_name&apos;, &apos;http://$service_name/&apos;, &apos;$service_description&apos;)&quot;;
-	docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure
+	docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure
 fi
 
 # Get the resource from the db 
 export SQL=&quot;SELECT LOWER(CONCAT(SUBSTR(HEX(uuid), 1, 8), &apos;-&apos;, SUBSTR(HEX(uuid), 9, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 13, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 17, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 21))) from picsure.resource where name = &apos;$service_name&apos;&quot;;
-export resource_uuid=$(docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
+export resource_uuid=$(docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
 echo &apos;&apos;
 echo &quot;Done adding to db. Using $resource_uuid as uuid&quot;; 
 

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure Auth0 Integration/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure Auth0 Integration/config.xml
@@ -46,6 +46,9 @@ sed -i &quot;s/$old_client_id/$AUTH0_CLIENT_ID/g&quot; /usr/local/docker-config/
 sed -i &quot;s/$old_tenant/$AUTH0_TENANT/g&quot; /usr/local/docker-config/httpd/picsureui_settings.json
 sed -i &quot;s/$old_tenant/$AUTH0_TENANT/g&quot; /usr/local/docker-config/wildfly/standalone.xml
 
+sed -i &quot;s/$old_client_secret/$AUTH0_CLIENT_SECRET/g&quot; /usr/local/docker-config/psama/.env
+sed -i &quot;s/$old_client_id/$AUTH0_CLIENT_ID/g&quot; /usr/local/docker-config/psama/.env
+sed -i &quot;s/$old_tenant/$AUTH0_TENANT/g&quot; /usr/local/docker-config/psama/.env
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure JupyterHub Token Introspection Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure JupyterHub Token Introspection Token/config.xml
@@ -50,7 +50,7 @@ export old_token_introspection_token=`cat /usr/local/docker-config/jupyterhub_co
 
 sed -i &quot;s/$old_token_introspection_token/$new_token_introspection_token/g&quot; /usr/local/docker-config/jupyterhub_config.py
 
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;update application set token=&apos;$new_token_introspection_token&apos; where uuid=$application_id;&quot; auth
 </command>
     </hudson.tasks.Shell>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure JupyterHub Token Introspection Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure JupyterHub Token Introspection Token/config.xml
@@ -50,7 +50,7 @@ export old_token_introspection_token=`cat /usr/local/docker-config/jupyterhub_co
 
 sed -i &quot;s/$old_token_introspection_token/$new_token_introspection_token/g&quot; /usr/local/docker-config/jupyterhub_config.py
 
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;update application set token=&apos;$new_token_introspection_token&apos; where uuid=$application_id;&quot; auth
 </command>
     </hudson.tasks.Shell>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure PIC-SURE Token Introspection Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure PIC-SURE Token Introspection Token/config.xml
@@ -50,7 +50,7 @@ sed -i &quot;s/$old_token_introspection_token/$new_token_introspection_token/g&q
 
 sed -i &quot;s/$old_token_introspection_token/$new_token_introspection_token/g&quot; /usr/local/docker-config/psama/.env
 
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;update application set token=&apos;$new_token_introspection_token&apos;;&quot; auth
 </command>
     </hudson.tasks.Shell>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure PIC-SURE Token Introspection Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure PIC-SURE Token Introspection Token/config.xml
@@ -50,7 +50,7 @@ sed -i &quot;s/$old_token_introspection_token/$new_token_introspection_token/g&q
 
 sed -i &quot;s/$old_token_introspection_token/$new_token_introspection_token/g&quot; /usr/local/docker-config/psama/.env
 
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;update application set token=&apos;$new_token_introspection_token&apos;;&quot; auth
 </command>
     </hudson.tasks.Shell>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure Remote MySQL Instance/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure Remote MySQL Instance/config.xml
@@ -96,18 +96,18 @@ AIRFLOW_PASSWORD=`grep &quot;password&quot; /usr/local/docker-config/flyway/auth
 PICSURE_PASSWORD=`sed -n &apos;s/&lt;password&gt;\(.*\)&lt;\/password&gt;/\1/p&apos; picsure.tmp | xargs` 
 AUTH_PASSWORD=`sed -n &apos;s/&lt;password&gt;\(.*\)&lt;\/password&gt;/\1/p&apos; auth.tmp | xargs` 
 
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on auth.* to &apos;airflow&apos;@&apos;%&apos; identified by &apos;$AIRFLOW_PASSWORD&apos;;flush privileges;&quot; mysql
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on picsure.* to &apos;airflow&apos;@&apos;%&apos; identified by &apos;$AIRFLOW_PASSWORD&apos;;flush privileges;&quot; mysql
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on picsure.* to &apos;picsure&apos;@&apos;%&apos; identified by &apos;$PICSURE_PASSWORD&apos;;flush privileges;&quot; mysql
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on auth.* to &apos;auth&apos;@&apos;%&apos; identified by &apos;$AUTH_PASSWORD&apos;;flush privileges;&quot; mysql
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on auth.* to &apos;airflow&apos;@&apos;%&apos; identified by &apos;$AIRFLOW_PASSWORD&apos;;flush privileges;&quot; mysql
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on picsure.* to &apos;airflow&apos;@&apos;%&apos; identified by &apos;$AIRFLOW_PASSWORD&apos;;flush privileges;&quot; mysql
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on picsure.* to &apos;picsure&apos;@&apos;%&apos; identified by &apos;$PICSURE_PASSWORD&apos;;flush privileges;&quot; mysql
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on auth.* to &apos;auth&apos;@&apos;%&apos; identified by &apos;$AUTH_PASSWORD&apos;;flush privileges;&quot; mysql
 
 if [ &quot;$DROP_EXISTING_TABLES&quot; = &quot;TRUE&quot;]; then
-  docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &amp;quot;drop database IF EXISTS auth;&amp;quot; mysql
-  docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &amp;quot;drop database IF EXISTS picsure;&amp;quot; mysql
+  docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &amp;quot;drop database IF EXISTS auth;&amp;quot; mysql
+  docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &amp;quot;drop database IF EXISTS picsure;&amp;quot; mysql
 fi
 
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;create database auth;&quot; mysql
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;create database picsure;&quot; mysql
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;create database auth;&quot; mysql
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;create database picsure;&quot; mysql
       </command>
       <configuredLocalRules/>
     </hudson.tasks.Shell>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure Remote MySQL Instance/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure Remote MySQL Instance/config.xml
@@ -82,10 +82,8 @@ sed -i &apos;/port/d&apos; ./sql.properties
 sed -i &quot;2iport=$MYSQL_PORT&quot; ./sql.properties
 
 sed -i &apos;s/jdbc:mysql*.*auth/jdbc:mysql:\/\/&apos;$MYSQL_HOST_NAME&apos;:&apos;$MYSQL_PORT&apos;\/auth/g&apos; /usr/local/docker-config/psama/.env
-sed -i &apos;s/jdbc:mysql*.*picsure/jdbc:mysql:\/\/&apos;$MYSQL_HOST_NAME&apos;:&apos;$MYSQL_PORT&apos;\/picsure/g&apos; /usr/local/docker-config/psama/.env
 
 cd /usr/local/docker-config/wildfly
-sed -i &apos;s/jdbc:mysql*.*auth/jdbc:mysql:\/\/&apos;$MYSQL_HOST_NAME&apos;:&apos;$MYSQL_PORT&apos;\/auth/g&apos; /usr/local/docker-config/wildfly/standalone.xml
 sed -i &apos;s/jdbc:mysql*.*picsure/jdbc:mysql:\/\/&apos;$MYSQL_HOST_NAME&apos;:&apos;$MYSQL_PORT&apos;\/picsure/g&apos; /usr/local/docker-config/wildfly/standalone.xml
 
 echo `grep &quot;password&quot; /usr/local/docker-config/flyway/auth/sql.properties | cut -d &quot;=&quot; -f2-` &gt;  airflow.tmp

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure Remote MySQL Instance/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure Remote MySQL Instance/config.xml
@@ -96,18 +96,18 @@ AIRFLOW_PASSWORD=`grep &quot;password&quot; /usr/local/docker-config/flyway/auth
 PICSURE_PASSWORD=`sed -n &apos;s/&lt;password&gt;\(.*\)&lt;\/password&gt;/\1/p&apos; picsure.tmp | xargs` 
 AUTH_PASSWORD=`sed -n &apos;s/&lt;password&gt;\(.*\)&lt;\/password&gt;/\1/p&apos; auth.tmp | xargs` 
 
-docker run -i -v /root/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on auth.* to &apos;airflow&apos;@&apos;%&apos; identified by &apos;$AIRFLOW_PASSWORD&apos;;flush privileges;&quot; mysql
-docker run -i -v /root/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on picsure.* to &apos;airflow&apos;@&apos;%&apos; identified by &apos;$AIRFLOW_PASSWORD&apos;;flush privileges;&quot; mysql
-docker run -i -v /root/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on picsure.* to &apos;picsure&apos;@&apos;%&apos; identified by &apos;$PICSURE_PASSWORD&apos;;flush privileges;&quot; mysql
-docker run -i -v /root/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on auth.* to &apos;auth&apos;@&apos;%&apos; identified by &apos;$AUTH_PASSWORD&apos;;flush privileges;&quot; mysql
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on auth.* to &apos;airflow&apos;@&apos;%&apos; identified by &apos;$AIRFLOW_PASSWORD&apos;;flush privileges;&quot; mysql
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on picsure.* to &apos;airflow&apos;@&apos;%&apos; identified by &apos;$AIRFLOW_PASSWORD&apos;;flush privileges;&quot; mysql
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on picsure.* to &apos;picsure&apos;@&apos;%&apos; identified by &apos;$PICSURE_PASSWORD&apos;;flush privileges;&quot; mysql
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;grant all privileges on auth.* to &apos;auth&apos;@&apos;%&apos; identified by &apos;$AUTH_PASSWORD&apos;;flush privileges;&quot; mysql
 
 if [ &quot;$DROP_EXISTING_TABLES&quot; = &quot;TRUE&quot;]; then
-  docker run -i -v /root/.my.cnf:/root/.my.cnf mysql mysql -e  &amp;quot;drop database IF EXISTS auth;&amp;quot; mysql
-  docker run -i -v /root/.my.cnf:/root/.my.cnf mysql mysql -e  &amp;quot;drop database IF EXISTS picsure;&amp;quot; mysql
+  docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &amp;quot;drop database IF EXISTS auth;&amp;quot; mysql
+  docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &amp;quot;drop database IF EXISTS picsure;&amp;quot; mysql
 fi
 
-docker run -i -v /root/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;create database auth;&quot; mysql
-docker run -i -v /root/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;create database picsure;&quot; mysql
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;create database auth;&quot; mysql
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf mysql mysql -e  &quot;create database picsure;&quot; mysql
       </command>
       <configuredLocalRules/>
     </hudson.tasks.Shell>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure Remote MySQL Instance/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure Remote MySQL Instance/config.xml
@@ -82,8 +82,10 @@ sed -i &apos;/port/d&apos; ./sql.properties
 sed -i &quot;2iport=$MYSQL_PORT&quot; ./sql.properties
 
 sed -i &apos;s/jdbc:mysql*.*auth/jdbc:mysql:\/\/&apos;$MYSQL_HOST_NAME&apos;:&apos;$MYSQL_PORT&apos;\/auth/g&apos; /usr/local/docker-config/psama/.env
+sed -i &apos;s/jdbc:mysql*.*picsure/jdbc:mysql:\/\/&apos;$MYSQL_HOST_NAME&apos;:&apos;$MYSQL_PORT&apos;\/picsure/g&apos; /usr/local/docker-config/psama/.env
 
 cd /usr/local/docker-config/wildfly
+sed -i &apos;s/jdbc:mysql*.*auth/jdbc:mysql:\/\/&apos;$MYSQL_HOST_NAME&apos;:&apos;$MYSQL_PORT&apos;\/auth/g&apos; /usr/local/docker-config/wildfly/standalone.xml
 sed -i &apos;s/jdbc:mysql*.*picsure/jdbc:mysql:\/\/&apos;$MYSQL_HOST_NAME&apos;:&apos;$MYSQL_PORT&apos;\/picsure/g&apos; /usr/local/docker-config/wildfly/standalone.xml
 
 echo `grep &quot;password&quot; /usr/local/docker-config/flyway/auth/sql.properties | cut -d &quot;=&quot; -f2-` &gt;  airflow.tmp

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Admin User/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Admin User/config.xml
@@ -32,11 +32,11 @@
     <hudson.tasks.Shell>
       <command>export USER_ID=`uuidgen -r`
 export USER_ID_HEX=`echo $USER_ID | awk &apos;{ print toupper($0) }&apos;|sed &apos;s/-//g&apos;`
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.user VALUES (unhex(&apos;$USER_ID_HEX&apos;), null, &apos;{\&quot;email\&quot;:\&quot;$EMAIL\&quot;}&apos;, null, (select uuid from connection where label=&apos;$CONNECTION_LABEL&apos;),&apos;$EMAIL&apos;,0,null,1,null);&quot; auth
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.user_role VALUES (unhex(&apos;$USER_ID_HEX&apos;), unhex(&apos;002DC366B0D8420F998F885D0ED797FD&apos;));&quot; auth
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.user_role VALUES (unhex(&apos;$USER_ID_HEX&apos;), unhex(&apos;797FD002DC366B0D8420F998F885D0ED&apos;));&quot; auth
 </command>
     </hudson.tasks.Shell>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Admin User/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Admin User/config.xml
@@ -32,11 +32,11 @@
     <hudson.tasks.Shell>
       <command>export USER_ID=`uuidgen -r`
 export USER_ID_HEX=`echo $USER_ID | awk &apos;{ print toupper($0) }&apos;|sed &apos;s/-//g&apos;`
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.user VALUES (unhex(&apos;$USER_ID_HEX&apos;), null, &apos;{\&quot;email\&quot;:\&quot;$EMAIL\&quot;}&apos;, null, (select uuid from connection where label=&apos;$CONNECTION_LABEL&apos;),&apos;$EMAIL&apos;,0,null,1,null);&quot; auth
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.user_role VALUES (unhex(&apos;$USER_ID_HEX&apos;), unhex(&apos;002DC366B0D8420F998F885D0ED797FD&apos;));&quot; auth
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.user_role VALUES (unhex(&apos;$USER_ID_HEX&apos;), unhex(&apos;797FD002DC366B0D8420F998F885D0ED&apos;));&quot; auth
 </command>
     </hudson.tasks.Shell>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Custom Login (IDP) Connection/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Custom Login (IDP) Connection/config.xml
@@ -41,11 +41,11 @@
     <hudson.tasks.Shell>
       <command>CONNECTION_ID=`uuidgen -r`
 CONNECTION_ID_HEX=`echo $CONNECTION_ID | awk &apos;{ print toupper($0) }&apos;|sed &apos;s/-//g&apos;;`
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.connection (uuid, label, id, subprefix, requiredFields) VALUES (unhex(&apos;$CONNECTION_ID_HEX&apos;), &apos;$CONNECTION_LABEL&apos;, &apos;$ID&apos;, &apos;$SUBPREFIX&apos;, &apos;$requiredFields&apos;);&quot; auth
 USER_MAPPING_ID=`uuidgen -r`
 USER_MAPPING_ID_HEX=`echo $USER_MAPPING_ID | awk &apos;{ print toupper($0) }&apos;|sed &apos;s/-//g&apos;;`
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.userMetadataMapping (uuid, auth0MetadataJsonPath, connectionId, generalMetadataJsonPath) VALUES (unhex(&apos;$USER_MAPPING_ID_HEX&apos;), &apos;\$.email&apos;, unhex(&apos;$CONNECTION_ID_HEX&apos;), &apos;\$.email&apos;);&quot; auth</command>
 
 echo &quot;Please now edit the connections.json file in the httpd container and add your IDP button there. For more instructions see: https://pic-sure.gitbook.io/pic-sure/&quot;

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Custom Login (IDP) Connection/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Custom Login (IDP) Connection/config.xml
@@ -41,11 +41,11 @@
     <hudson.tasks.Shell>
       <command>CONNECTION_ID=`uuidgen -r`
 CONNECTION_ID_HEX=`echo $CONNECTION_ID | awk &apos;{ print toupper($0) }&apos;|sed &apos;s/-//g&apos;;`
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.connection (uuid, label, id, subprefix, requiredFields) VALUES (unhex(&apos;$CONNECTION_ID_HEX&apos;), &apos;$CONNECTION_LABEL&apos;, &apos;$ID&apos;, &apos;$SUBPREFIX&apos;, &apos;$requiredFields&apos;);&quot; auth
 USER_MAPPING_ID=`uuidgen -r`
 USER_MAPPING_ID_HEX=`echo $USER_MAPPING_ID | awk &apos;{ print toupper($0) }&apos;|sed &apos;s/-//g&apos;;`
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;INSERT INTO auth.userMetadataMapping (uuid, auth0MetadataJsonPath, connectionId, generalMetadataJsonPath) VALUES (unhex(&apos;$USER_MAPPING_ID_HEX&apos;), &apos;\$.email&apos;, unhex(&apos;$CONNECTION_ID_HEX&apos;), &apos;\$.email&apos;);&quot; auth</command>
 
 echo &quot;Please now edit the connections.json file in the httpd container and add your IDP button there. For more instructions see: https://pic-sure.gitbook.io/pic-sure/&quot;

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE Aggregate Resource/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE Aggregate Resource/config.xml
@@ -93,7 +93,7 @@ RESOURCE_ID_HEX=`echo $RESOURCE_ID | awk &apos;{ print toupper($0) }&apos;|sed &
 export SQL=&quot;INSERT INTO resource (uuid, targetURL, resourceRSPath, description, name, token) \
  VALUES (unhex(&apos;$RESOURCE_ID_HEX&apos;), NULL, &apos;http://wildfly:8080/$RESOURCE_PATH/pic-sure/aggregate-data-sharing/&apos;, &apos;$RESOURCE_DESC&apos;, &apos;$RESOURCE_NAME&apos;, NULL);&quot;
 
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE Aggregate Resource/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE Aggregate Resource/config.xml
@@ -93,7 +93,7 @@ RESOURCE_ID_HEX=`echo $RESOURCE_ID | awk &apos;{ print toupper($0) }&apos;|sed &
 export SQL=&quot;INSERT INTO resource (uuid, targetURL, resourceRSPath, description, name, token) \
  VALUES (unhex(&apos;$RESOURCE_ID_HEX&apos;), NULL, &apos;http://wildfly:8080/$RESOURCE_PATH/pic-sure/aggregate-data-sharing/&apos;, &apos;$RESOURCE_DESC&apos;, &apos;$RESOURCE_NAME&apos;, NULL);&quot;
 
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE PassThrough Resource/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE PassThrough Resource/config.xml
@@ -102,7 +102,7 @@ RESOURCE_ID_HEX=`echo $RESOURCE_ID | awk &apos;{ print toupper($0) }&apos;|sed &
 export SQL=&quot;INSERT INTO resource (uuid, targetURL, resourceRSPath, description, name, token) \
  VALUES (unhex(&apos;$RESOURCE_ID_HEX&apos;), NULL, &apos;http://wildfly:8080/$RESOURCE_PATH/pic-sure/passthru/&apos;, &apos;$RESOURCE_DESC&apos;, &apos;$RESOURCE_NAME&apos;, NULL);&quot;
 
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE PassThrough Resource/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE PassThrough Resource/config.xml
@@ -102,7 +102,7 @@ RESOURCE_ID_HEX=`echo $RESOURCE_ID | awk &apos;{ print toupper($0) }&apos;|sed &
 export SQL=&quot;INSERT INTO resource (uuid, targetURL, resourceRSPath, description, name, token) \
  VALUES (unhex(&apos;$RESOURCE_ID_HEX&apos;), NULL, &apos;http://wildfly:8080/$RESOURCE_PATH/pic-sure/passthru/&apos;, &apos;$RESOURCE_DESC&apos;, &apos;$RESOURCE_NAME&apos;, NULL);&quot;
 
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Root Certs in TrustStore/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Root Certs in TrustStore/config.xml
@@ -13,6 +13,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>
+        <!--Remove existing wildfly trust store so it doesn't break-->
         rm -f /usr/local/docker-config/wildfly/application.truststore
 
         <!--Download certs-->
@@ -22,6 +23,15 @@
         <!--Import Certs to trust store-->
         keytool -import -keystore /usr/local/docker-config/wildfly/application.truststore -storepass password -noprompt -trustcacerts -alias letsencryptauthority1 -file isrgrootx1.der -storetype JKS
         keytool -import -keystore /usr/local/docker-config/wildfly/application.truststore -storepass password -noprompt -trustcacerts -alias letsencryptauthority2 -file lets-encrypt-r3.der -storetype JKS
+
+        <!--Remove existing psama trust store so it doesn't break-->
+        rm -rf /usr/local/docker-config/psama/application.truststore
+
+        curl https://letsencrypt.org/certs/isrgrootx1.der -o isrgrootx1.der
+        curl https://letsencrypt.org/certs/lets-encrypt-r3.der -o lets-encrypt-r3.der
+
+        keytool -import -keystore /usr/local/docker-config/psama/application.truststore -storepass password -noprompt -trustcacerts -alias letsencryptauthority1 -file isrgrootx1.der -storetype JKS
+        keytool -import -keystore /usr/local/docker-config/psama/application.truststore -storepass password -noprompt -trustcacerts -alias letsencryptauthority2 -file lets-encrypt-r3.der -storetype JKS
       </command>
     </hudson.tasks.Shell>
   </builders>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Root Certs in TrustStore/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Root Certs in TrustStore/config.xml
@@ -13,6 +13,8 @@
   <builders>
     <hudson.tasks.Shell>
       <command>
+        rm -f /usr/local/docker-config/wildfly/application.truststore
+
         <!--Download certs-->
         curl https://letsencrypt.org/certs/isrgrootx1.der -o isrgrootx1.der
         curl https://letsencrypt.org/certs/lets-encrypt-r3.der -o lets-encrypt-r3.der

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Test Users/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Test Users/config.xml
@@ -61,7 +61,7 @@ function run_sql_procedure() {
     local connection_id=&quot;$2&quot;
     local role_name=&quot;$3&quot;
 
-    docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+    docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
     &quot;CALL CreateUserWithRole(&apos;$user_email&apos;, &apos;$connection_id&apos;, &apos;$role_name&apos;, &apos;{\&quot;email\&quot;: \&quot;$user_email\&quot;}&apos;);&quot; auth
 }
 
@@ -74,14 +74,14 @@ function update_user_token() {
     grep client_secret /usr/local/docker-config/wildfly/standalone.xml | cut -d &apos;=&apos; -f 3 | sed &apos;s/[\&quot;/\&gt;]//g&apos; &gt; secret.txt
 
     # Get the user subject by email
-    USER_SUBJECT=$(docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=host mysql mysql -N -e \
+    USER_SUBJECT=$(docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=host mysql mysql -N -e \
     &quot;SELECT subject FROM auth.user where email=&apos;$USERNAME&apos;;&quot;)
 
     # Create a new user token by subject and expiry
     user_token=$(java -jar target/generateJwt.jar secret.txt sub &quot;${USER_SUBJECT}&quot; ${DAYSUNTILEXPIRATION} day | grep -v &quot;Generating&quot;)
 
     # Update user with the new token
-    docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+    docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
     &quot;update auth.user set long_term_token=&apos;$user_token&apos; where email=&apos;$USERNAME&apos;;&quot;
 
     # Return the newly generated user token

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create Test Users/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create Test Users/config.xml
@@ -61,7 +61,7 @@ function run_sql_procedure() {
     local connection_id=&quot;$2&quot;
     local role_name=&quot;$3&quot;
 
-    docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+    docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
     &quot;CALL CreateUserWithRole(&apos;$user_email&apos;, &apos;$connection_id&apos;, &apos;$role_name&apos;, &apos;{\&quot;email\&quot;: \&quot;$user_email\&quot;}&apos;);&quot; auth
 }
 
@@ -74,14 +74,14 @@ function update_user_token() {
     grep client_secret /usr/local/docker-config/wildfly/standalone.xml | cut -d &apos;=&apos; -f 3 | sed &apos;s/[\&quot;/\&gt;]//g&apos; &gt; secret.txt
 
     # Get the user subject by email
-    USER_SUBJECT=$(docker run -i -v /root/.my.cnf:/root/.my.cnf --network=host mysql mysql -N -e \
+    USER_SUBJECT=$(docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=host mysql mysql -N -e \
     &quot;SELECT subject FROM auth.user where email=&apos;$USERNAME&apos;;&quot;)
 
     # Create a new user token by subject and expiry
     user_token=$(java -jar target/generateJwt.jar secret.txt sub &quot;${USER_SUBJECT}&quot; ${DAYSUNTILEXPIRATION} day | grep -v &quot;Generating&quot;)
 
     # Update user with the new token
-    docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+    docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
     &quot;update auth.user set long_term_token=&apos;$user_token&apos; where email=&apos;$USERNAME&apos;;&quot;
 
     # Return the newly generated user token

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Export builds/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Export builds/config.xml
@@ -1,0 +1,48 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@332.va_1ee476d8f6d">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+
+# Jenkins jobs directory
+jenkinsJobsDir=&quot;/var/jenkins_home/jobs&quot;
+
+# Output tar file name
+outputFileName=&quot;jenkins_jobs_backup.tar.gz&quot;
+
+# Find all config.xml files and pass them to tar for archiving
+find $jenkinsJobsDir -type f -name &quot;config.xml&quot; -print0 | tar -czvf $outputFileName --null -T -
+
+echo &quot;Backup completed: $outputFileName&quot;</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>jenkins_jobs_backup.tar.gz</artifacts>
+      <allowEmptyArchive>false</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+      <followSymlinks>false</followSymlinks>
+    </hudson.tasks.ArtifactArchiver>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Initial Configuration Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Initial Configuration Pipeline/config.xml
@@ -70,10 +70,10 @@
 
 def retrieveBuildSpecId;
 def pipelineBuildId;
-def build_hashes = {
+def build_hashes = [
     DICTIONARY: false
     UPLOADER: false
-};
+];
 pipeline {
     agent any 
     stages {

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Initial Configuration Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Initial Configuration Pipeline/config.xml
@@ -71,7 +71,7 @@
 def retrieveBuildSpecId;
 def pipelineBuildId;
 def build_hashes = [
-    DICTIONARY: false
+    DICTIONARY: false,
     UPLOADER: false
 ];
 pipeline {

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Pipeline/config.xml
@@ -17,10 +17,10 @@
 
 def retrieveBuildSpecId;
 def pipelineBuildId;
-def build_hashes = {
+def build_hashes = [
     DICTIONARY: false
     UPLOADER: false
-};
+];
 pipeline {
     agent any
     stages {

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Pipeline/config.xml
@@ -18,7 +18,7 @@
 def retrieveBuildSpecId;
 def pipelineBuildId;
 def build_hashes = [
-    DICTIONARY: false
+    DICTIONARY: false,
     UPLOADER: false
 ];
 pipeline {

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Passthrough Resource Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Passthrough Resource Pipeline/config.xml
@@ -58,10 +58,10 @@
 
 def retrieveBuildSpecId;
 def pipelineBuildId;
-def build_hashes = {
+def build_hashes = [
     DICTIONARY: false
     UPLOADER: false
-};
+];
 def resourceURL = "https://${SERVERNAME}/picsure/"
  
 pipeline {

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Passthrough Resource Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Passthrough Resource Pipeline/config.xml
@@ -59,7 +59,7 @@
 def retrieveBuildSpecId;
 def pipelineBuildId;
 def build_hashes = [
-    DICTIONARY: false
+    DICTIONARY: false,
     UPLOADER: false
 ];
 def resourceURL = "https://${SERVERNAME}/picsure/"

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Remove Test Users/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Remove Test Users/config.xml
@@ -29,14 +29,14 @@ function delete_user_by_email() {
     # SQL command to remove user from assoc
     local remove_user_role=&quot;DELETE FROM auth.user_role WHERE user_id in (SELECT uuid FROM auth.user where email = &apos;$user_email&apos;);&quot;
 
-    docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+    docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
     &quot;$remove_user_role&quot; auth
 
     # SQL command to delete a user based on their email
     local remove_user=&quot;DELETE FROM auth.user WHERE email = &apos;$user_email&apos;;&quot;
 
     # Run the command using Docker and MySQL client
-    docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+    docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
     &quot;$remove_user&quot; auth
 }
 

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Remove Test Users/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Remove Test Users/config.xml
@@ -29,14 +29,14 @@ function delete_user_by_email() {
     # SQL command to remove user from assoc
     local remove_user_role=&quot;DELETE FROM auth.user_role WHERE user_id in (SELECT uuid FROM auth.user where email = &apos;$user_email&apos;);&quot;
 
-    docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+    docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
     &quot;$remove_user_role&quot; auth
 
     # SQL command to delete a user based on their email
     local remove_user=&quot;DELETE FROM auth.user WHERE email = &apos;$user_email&apos;;&quot;
 
     # Run the command using Docker and MySQL client
-    docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+    docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
     &quot;$remove_user&quot; auth
 }
 

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Update User Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Update User Token/config.xml
@@ -58,12 +58,12 @@
 cd target
 grep client_secret /usr/local/docker-config/wildfly/standalone.xml | cut -d &apos;=&apos; -f 3 | sed &apos;s/[\&quot;/\&gt;]//g&apos; &gt; secret.txt
 
-export USER_SUBJECT=`docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -N -e \
+export USER_SUBJECT=`docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -N -e \
 &quot;SELECT subject FROM auth.user where email=&apos;$USERNAME&apos;; &quot;`
 
 export user_token=`java -jar generateJwt.jar secret.txt sub &quot;${USER_SUBJECT}&quot; ${DAYSUNTILEXPIRATION} day | grep -v &quot;Generating&quot;`
 
-docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $MYSQL_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;update auth.user set long_term_token=&apos;$user_token&apos;  where email=&apos;$USERNAME&apos;;&quot; 
 
 </command>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Update User Token/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Update User Token/config.xml
@@ -58,12 +58,12 @@
 cd target
 grep client_secret /usr/local/docker-config/wildfly/standalone.xml | cut -d &apos;=&apos; -f 3 | sed &apos;s/[\&quot;/\&gt;]//g&apos; &gt; secret.txt
 
-export USER_SUBJECT=`docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -N -e \
+export USER_SUBJECT=`docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -N -e \
 &quot;SELECT subject FROM auth.user where email=&apos;$USERNAME&apos;; &quot;`
 
 export user_token=`java -jar generateJwt.jar secret.txt sub &quot;${USER_SUBJECT}&quot; ${DAYSUNTILEXPIRATION} day | grep -v &quot;Generating&quot;`
 
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
+docker run -i -v $DOCKER_CONFIG_DIR/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e \
 &quot;update auth.user set long_term_token=&apos;$user_token&apos;  where email=&apos;$USERNAME&apos;;&quot; 
 
 </command>

--- a/initial-configuration/mysql-docker/setup.sh
+++ b/initial-configuration/mysql-docker/setup.sh
@@ -9,10 +9,12 @@ if [ -z "$(docker ps --format '{{.Names}}' | grep picsure-db)" ]; then
   echo "Cleaning up old configs"
   rm -r "${DOCKER_CONFIG_DIR:?}"/*
   cp -r config/* "$DOCKER_CONFIG_DIR"/
+  rm -f "$MYSQL_CONFIG_DIR"/.my.cnf
 
   echo "Starting mysql server"
   echo "$( < /dev/urandom tr -dc @^=+$*%_A-Z-a-z-0-9 | head -c${1:-24})" > pass.tmp
   rm -f mysql-docker/.env
+
   # shellcheck disable=SC2129
   echo "PICSURE_DB_ROOT_PASS=`cat pass.tmp`" >> mysql-docker/.env
   echo "PICSURE_DB_PASS=`cat pass.tmp`" >> mysql-docker/.env
@@ -22,11 +24,11 @@ if [ -z "$(docker ps --format '{{.Names}}' | grep picsure-db)" ]; then
 
   echo "Configuring .my.cnf"
   # shellcheck disable=SC2129
-  echo "[mysql]" >> "$HOME"/.my.cnf
-  echo "user=root" >> "$HOME"/.my.cnf
-  echo "password=\"$(cat pass.tmp)\"" >> "$HOME"/.my.cnf
-  echo "host=picsure-db" >> "$HOME"/.my.cnf
-  echo "port=3306" >> "$HOME"/.my.cnf
+  echo "[mysql]" >> "$MYSQL_CONFIG_DIR"/.my.cnf
+  echo "user=root" >> "$MYSQL_CONFIG_DIR"/.my.cnf
+  echo "password=\"$(cat pass.tmp)\"" >> "$MYSQL_CONFIG_DIR"/.my.cnf
+  echo "host=picsure-db" >> "$MYSQL_CONFIG_DIR"/.my.cnf
+  echo "port=3306" >> "$MYSQL_CONFIG_DIR"/.my.cnf
 
   cd mysql-docker
   docker compose up -d

--- a/initial-configuration/mysql-docker/setup.sh
+++ b/initial-configuration/mysql-docker/setup.sh
@@ -18,6 +18,7 @@ if [ -z "$(docker ps --format '{{.Names}}' | grep picsure-db)" ]; then
   echo "PICSURE_DB_PASS=`cat pass.tmp`" >> mysql-docker/.env
   echo "PICSURE_DB_DATABASE=ignore" >> mysql-docker/.env
   echo "PICSURE_DB_USER=ignore" >> mysql-docker/.env
+  echo "DOCKER_CONFIG_DIR=$DOCKER_CONFIG_DIR" >> mysql-docker/.env
 
   echo "Configuring .my.cnf"
   # shellcheck disable=SC2129

--- a/initial-configuration/pass.tmp
+++ b/initial-configuration/pass.tmp
@@ -1,1 +1,0 @@
-30Ik2r_^Y9CppDHHvmtbGzNf

--- a/reset_development_environment.sh
+++ b/reset_development_environment.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Check if DOCKER_CONFIG_DIR is set, if not, use default
+if [ -z "$DOCKER_CONFIG_DIR" ]; then
+  echo "DOCKER_CONFIG_DIR is not set. Defaulting to /var/local/docker-config."
+  DOCKER_CONFIG_DIR="/var/local/docker-config"
+else
+  echo "DOCKER_CONFIG_DIR is set to $DOCKER_CONFIG_DIR"
+fi
+
+# Ensure DOCKER_CONFIG_DIR is not set to root "/"
+if [ "$DOCKER_CONFIG_DIR" = "/" ]; then
+  echo "Error: DOCKER_CONFIG_DIR is set to root '/'. Aborting to prevent system damage."
+  exit 1
+fi
+
+#$MYSQL_CONFIG_DIR
+if [ -z "$MYSQL_CONFIG_DIR" ]; then
+  echo "MYSQL_CONFIG_DIR is not set. Defaulting to $DOCKER_CONFIG_DIR."
+  MYSQL_CONFIG_DIR="$DOCKER_CONFIG_DIR"
+else
+  echo "MYSQL_CONFIG_DIR is set to $MYSQL_CONFIG_DIR"
+fi
+
+# Ensure DOCKER_CONFIG_DIR is not set to root "/"
+if [ "$DOCKER_CONFIG_DIR" = "/" ]; then
+  echo "Error: DOCKER_CONFIG_DIR is set to root '/'. Aborting to prevent system damage."
+  exit 1
+fi
+
+# Step 1: Run stop-picsure.sh
+echo "Stopping PIC-SURE..."
+./stop-picsure.sh
+
+# Step 2: Run stop-jenkin.sh
+echo "Stopping Jenkins..."
+./stop-jenkin.sh
+
+# Step 3: Stop and remove the picsure-db container
+echo "Stopping and removing PIC-SURE database container..."
+docker stop picsure-db
+docker rm picsure-db
+
+# Step 4: Run docker system prune -a
+echo "Pruning Docker system and removing all images..."
+docker system prune -a -f
+
+# Step 5: Clear the MYSQL_CONFIG_DIR
+echo "Clearing the MySQL configuration directory..."
+rm -rf "$MYSQL_CONFIG_DIR/*"
+
+# Step 6: Clear the DOCKER_CONFIG_DIR
+echo "Clearing the Docker configuration directory..."
+rm -rf "$DOCKER_CONFIG_DIR/*"
+
+# Step 7: Remove the jenkins_home directory and recreate necessary directories
+echo "Removing and recreating Jenkins and log directories..."
+sudo rm -rf /var/jenkins_home
+sudo rm -rf /var/log/jenkins-docker-logs
+sudo rm -rf /var/jenkins_home_bak
+
+sudo mkdir -p /var/log/jenkins-docker-logs
+sudo mkdir -p /var/jenkins_home
+sudo mkdir -p /var/jenkins_home_bak
+sudo mkdir -p /var/log/httpd-docker-logs/ssl_mutex
+
+# Step 8: Set permissions for the directories
+echo "Setting permissions for Jenkins and log directories..."
+sudo chmod -R 777 /var/jenkins_home
+sudo chmod -R 777 /var/jenkins_home_bak
+sudo chmod -R 777 /var/log/httpd-docker-logs
+
+echo "All steps completed successfully."

--- a/start-jenkins.sh
+++ b/start-jenkins.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 DOCKER_CONFIG_DIR="${DOCKER_CONFIG_DIR:-/usr/local/docker-config}"
+MY_SQL_DIR="${MY_SQL_DIR:-/root/}"
 
 if [ -f $DOCKER_CONFIG_DIR/setProxy.sh ]; then
    . $DOCKER_CONFIG_DIR/setProxy.sh
@@ -15,8 +16,8 @@ docker run -d \
   -v /var/jenkins_home:/var/jenkins_home \
   -v "$DOCKER_CONFIG_DIR":/usr/local/docker-config \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v "$HOME"/.my.cnf:/root/.my.cnf \
-  -v "$HOME"/.m2:/root/.m2 \
+  -v "$MYSQL_CONFIG_DIR"/.my.cnf:/root/.my.cnf \
+  -v "$MYSQL_CONFIG_DIR"/.m2:/root/.m2 \
   -v /etc/hosts:/etc/hosts \
   -v /usr/local/pic-sure-services:/pic-sure-services \
   -p 8080:8080 --name jenkins pic-sure-jenkins:LATEST

--- a/start-picsure.sh
+++ b/start-picsure.sh
@@ -92,6 +92,6 @@ docker run --name=wildfly --restart always --network=picsure -u root \
   -e JAVA_OPTS="$WILDFLY_JAVA_OPTS $TRUSTSTORE_JAVA_OPTS" \
   -d hms-dbmi/pic-sure-wildfly:LATEST
 
-if test -d $DOCKER_CONFIG_DIR/dictionary then
+if [ -d $DOCKER_CONFIG_DIR/dictionary ]; then
   docker compose -f $DOCKER_CONFIG_DIR/dictionary/docker-compose.yml --env-file $DOCKER_CONFIG_DIR/dictionary/.env up -d
 fi

--- a/start-picsure.sh
+++ b/start-picsure.sh
@@ -34,8 +34,18 @@ export PROFILING_OPTS=" -Dcom.sun.management.jmxremote=true -Dcom.sun.management
 if [ -f $DOCKER_CONFIG_DIR/wildfly/application.truststore ]; then
 	export TRUSTSTORE_VOLUME="-v $DOCKER_CONFIG_DIR/wildfly/application.truststore:/opt/jboss/wildfly/standalone/configuration/application.truststore"
   export TRUSTSTORE_JAVA_OPTS="-Djavax.net.ssl.trustStore=/opt/jboss/wildfly/standalone/configuration/application.truststore -Djavax.net.ssl.trustStorePassword=password"
+else
+  echo "wildfly truststore not found"
+  exit 2
 fi
 
+if [ -f $DOCKER_CONFIG_DIR/psama/application.truststore ]; then
+    export PSAMA_TRUSTSTORE_VOLUME="-v $DOCKER_CONFIG_DIR/psama/application.truststore:/usr/local/tomcat/conf/application.truststore"
+    export PSAMA_TRUSTSTORE_JAVA_OPTS="-Djavax.net.ssl.trustStore=/usr/local/tomcat/conf/application.truststore -Djavax.net.ssl.trustStorePassword=password"
+else
+    echo "pic-sure-auth-micro-app (psama) truststore not found"
+    exit 2
+fi
 
 docker stop hpds && docker rm hpds
 docker run --name=hpds --restart always --network=picsure \
@@ -71,8 +81,8 @@ docker run --name=psama --restart always \
   --network=picsure \
   --env-file $DOCKER_CONFIG_DIR/psama/.env \
   $EMAIL_TEMPLATE_VOUME \
-  $TRUSTSTORE_VOLUME \
-  -e JAVA_OPTS="$PSAMA_OPTS $TRUSTSTORE_JAVA_OPTS" \
+  $PSAMA_TRUSTSTORE_VOLUME \
+  -e JAVA_OPTS="$PSAMA_OPTS $PSAMA_TRUSTSTORE_JAVA_OPTS" \
   -d hms-dbmi/psama:LATEST
 
 docker stop wildfly && docker rm wildfly

--- a/stop-picsure.sh
+++ b/stop-picsure.sh
@@ -4,6 +4,6 @@ docker stop httpd && docker rm httpd
 docker stop wildfly && docker rm wildfly
 docker stop psama && docker rm psama
 
-if test -d $DOCKER_CONFIG_DIR/dictionary then
+if [ -d $DOCKER_CONFIG_DIR/dictionary ]; then
   docker compose -f $DOCKER_CONFIG_DIR/dictionary/docker-compose.yml --env-file $DOCKER_CONFIG_DIR/dictionary/.env down
 fi


### PR DESCRIPTION
- Update Initial Configuration to include the pic-sure-auth-micro-apps .env file.
- MySQL `.my.cnf` is path is now configurable. You can now pass a second directory path to the `install-dependencies-docker.sh`. This second path will be used to set the `.my.cnf` path.
- Fixed `build_hashes` used in a few pipelines by converting it to an array.
- When creating trust store for WildFly we now first delete the existing trust store to prevent the job from failing.