### PR TITLE
Rename job in Jenkins pipeline configuration

### DIFF
--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Pipeline/config.xml
@@ -69,7 +69,7 @@ pipeline {
                         },
                         picsureauth:{
                             script{
-                                def result = build job: &apos;PIC-SURE Auth Micro-App Build&apos;, parameters: [[$class: &apos;StringParameterValue&apos;, name: &apos;pipeline_build_id&apos;, value: pipelineBuildId],[$class: &apos;StringParameterValue&apos;, name: &apos;git_hash&apos;, value: build_hashes[&apos;PSAMA&apos;]]]
+                                def result = build job: &apos;PIC-SURE Auth Micro-App Build - Jenkinsfile&apos;, parameters: [[$class: &apos;StringParameterValue&apos;, name: &apos;pipeline_build_id&apos;, value: pipelineBuildId],[$class: &apos;StringParameterValue&apos;, name: &apos;git_hash&apos;, value: build_hashes[&apos;PSAMA&apos;]]]
                             }
                         }
                 )


### PR DESCRIPTION
Updated the name of the Jenkins job from 'PIC-SURE Auth Micro-App Build' to 'PIC-SURE Auth Micro-App Build - Jenkinsfile' in the pipeline configuration. This ensures alignment with the correct job naming conventions.