### PR TITLE
Update branch references from 'master' to 'main'

### DIFF
--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Auth Micro-App Build/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Auth Micro-App Build/config.xml
@@ -15,7 +15,7 @@
         <hudson.model.StringParameterDefinition>
           <name>git_hash</name>
           <description></description>
-          <defaultValue>*/master</defaultValue>
+          <defaultValue>*/main</defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Wildfly Image Build/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Wildfly Image Build/config.xml
@@ -24,7 +24,7 @@
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>*/main</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>


### PR DESCRIPTION
Updated Jenkins job configurations to use 'main' instead of 'master' in branch specs and default parameter values. 