### PR TITLE
Disable Open Access By Default

### DIFF
--- a/initial-configuration/config/wildfly/standalone.xml
+++ b/initial-configuration/config/wildfly/standalone.xml
@@ -443,7 +443,7 @@
                 <simple name="java:global/verify_user_method" value="tokenIntrospection"/>
                 <simple name="java:global/token_introspection_url" value="http://psama:8090/auth/token/inspect"/>
 
-                <simple name="java:global/openAccessEnabled" value="true"/>
+                <simple name="java:global/openAccessEnabled" value="false"/>
                 <simple name="java:global/openAccessValidateUrl" value="http://psama:8090/auth/open/validate"/>
 
                 <simple name="java:global/token_introspection_token" value="__PIC_SURE_TOKEN_INTROSPECTION_TOKEN__"/>


### PR DESCRIPTION
Open access will now be disabled by default in the all-in-one as it is not supported.