### PR TITLE
[ALS-8912] NHANES: StatViz doesn't work

### DIFF
--- a/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE Visualization Build/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Create PIC-SURE Visualization Build/config.xml
@@ -26,7 +26,7 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.1">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.2">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -46,9 +46,18 @@
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <jdk>(System)</jdk>
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
+    <hudson.tasks.Maven>
+      <targets>clean install -DskipTests -Dwildfly.skip=true</targets>
+      <mavenName>Maven Home</mavenName>
+      <usePrivateRepository>false</usePrivateRepository>
+      <settings class="jenkins.mvn.DefaultSettingsProvider"/>
+      <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
+      <injectBuildVariables>false</injectBuildVariables>
+    </hudson.tasks.Maven>
     <hudson.tasks.Shell>
       <command># Copy WAR file from PIC-SURE-API Build resources
 cd pic-sure-resources/pic-sure-visualization-resource
@@ -57,7 +66,7 @@ cp target/pic-sure-visualization-resource.war /usr/local/docker-config/wildfly/d
 
 # Make properties config file
 export SQL=&quot;SELECT LOWER(CONCAT(SUBSTR(HEX(uuid), 1, 8), &apos;-&apos;, SUBSTR(HEX(uuid), 9, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 13, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 17, 4), &apos;-&apos;, SUBSTR(HEX(uuid), 21))) from picsure.resource where name = &apos;hpds&apos;&quot;;
-HPDS_ID=$(docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
+HPDS_ID=$(docker run -i -v &quot;${MYSQL_CONFIG_DIR}&quot;.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -se &quot;$SQL&quot; picsure);
 RESOURCE_ID=`uuidgen -r`
 
 mkdir -p /usr/local/docker-config/wildfly/visualization/$RESOURCE_PATH
@@ -75,7 +84,7 @@ export SQL=&quot;INSERT INTO resource (uuid, targetURL, resourceRSPath, descript
  VALUES (unhex(&apos;$RESOURCE_ID_HEX&apos;), NULL, &apos;http://wildfly:8080/$RESOURCE_PATH/pic-sure/visualization/&apos;, &apos;$RESOURCE_DESC&apos;, &apos;$RESOURCE_NAME&apos;, NULL);&quot;
 
 # Run with config
-docker run -i -v /root/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
+docker run -i -v &quot;$MYSQL_CONFIG_DIR&quot;/.my.cnf:/root/.my.cnf --network=${MYSQL_NETWORK:-host} mysql mysql -e &quot;$SQL&quot; picsure</command>
       <configuredLocalRules/>
     </hudson.tasks.Shell>
   </builders>

--- a/start-picsure.sh
+++ b/start-picsure.sh
@@ -59,6 +59,9 @@ docker run --name=psama --restart always \
   || exit 2
 
 docker stop wildfly && docker rm wildfly
+# destroy volume if it exists and create a new one
+docker volume rm wildflyDeployments || true
+docker volume create --name=wildflyDeployments
 docker run --name=wildfly --restart always --network=picsure -u root \
   -v "$DOCKER_CONFIG_DIR"/log/wildfly-docker-logs/:/opt/jboss/wildfly/standalone/log/ \
   -v /etc/hosts:/etc/hosts \
@@ -69,11 +72,16 @@ docker run --name=wildfly --restart always --network=picsure -u root \
   -v $DOCKER_CONFIG_DIR/wildfly/standalone.xml:/opt/jboss/wildfly/standalone/configuration/standalone.xml \
   $TRUSTSTORE_VOLUME \
   $EMAIL_TEMPLATE_VOLUME \
+  -v $DOCKER_CONFIG_DIR/wildfly/deployments:/opt/jboss/wildfly/standalone/deployments \
   -v $DOCKER_CONFIG_DIR/wildfly/wildfly_mysql_module.xml:/opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/module.xml  \
   -v $DOCKER_CONFIG_DIR/wildfly/mysql-connector-java-5.1.49.jar:/opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/mysql-connector-java-5.1.49.jar  \
   --env-file $CURRENT_FS_DOCKER_CONFIG_DIR/wildfly/wildfly.env \
   -d hms-dbmi/pic-sure-wildfly:LATEST \
   || exit 2
+# Workaround for macOS bind-mount limitations: macOS does not support atomic file moves on mounted volumes,
+# causing "Device or resource busy" errors during hot deployments. By using a Docker-managed volume and
+# copying deployments into the running container, we avoid this issue across all supported platforms.
+docker cp $DOCKER_CONFIG_DIR/wildfly/deployments/. wildfly:/opt/jboss/wildfly/standalone/deployments/
 
 docker stop dictionary-api && docker rm dictionary-api
 docker run --name dictionary-api --restart always \

--- a/start-picsure.sh
+++ b/start-picsure.sh
@@ -72,7 +72,7 @@ docker run --name=wildfly --restart always --network=picsure -u root \
   -v $DOCKER_CONFIG_DIR/wildfly/standalone.xml:/opt/jboss/wildfly/standalone/configuration/standalone.xml \
   $TRUSTSTORE_VOLUME \
   $EMAIL_TEMPLATE_VOLUME \
-  -v $DOCKER_CONFIG_DIR/wildfly/deployments:/opt/jboss/wildfly/standalone/deployments \
+  -v wildflyDeployments:/opt/jboss/wildfly/standalone/deployments \
   -v $DOCKER_CONFIG_DIR/wildfly/wildfly_mysql_module.xml:/opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/module.xml  \
   -v $DOCKER_CONFIG_DIR/wildfly/mysql-connector-java-5.1.49.jar:/opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/mysql-connector-java-5.1.49.jar  \
   --env-file $CURRENT_FS_DOCKER_CONFIG_DIR/wildfly/wildfly.env \


### PR DESCRIPTION
### Refactor WildFly volume management and deployment handling
- Add Docker-managed volume for WildFly deployments, replacing bind mounts. This addresses macOS file system limitations that cause errors during deployments, ensuring compatibility across platforms.

### Update Jenkins job configuration for PIC-SURE Visualization
- Add Maven build step with specific targets. 
- Adjust MySQL volume path handling to use the MYSQL_CONFIG_DIR var.