### PR TITLE
Create log directory before initializing MySQL

### DIFF
--- a/initial-configuration/install-dependencies-docker.sh
+++ b/initial-configuration/install-dependencies-docker.sh
@@ -213,7 +213,8 @@ fi
 #                                           MySQL Start                                           #
 #                                 Install Mysql and configure DB                                  #
 #-------------------------------------------------------------------------------------------------#
-./mysql-docker/setup.sh 2>&1 | tee "/var/log/picsure_mysql_init.log"
+mkdir -p "$DOCKER_CONFIG_DIR/log"
+./mysql-docker/setup.sh 2>&1 | tee "$DOCKER_CONFIG_DIR/log/picsure_mysql_init.log"
 
 #-------------------------------------------------------------------------------------------------#
 #                                         Jenkins Install                                         #


### PR DESCRIPTION
Ensure the Docker configuration log directory exists to avoid potential errors when saving MySQL initialization logs. This change improves script robustness during setup.