### PR TITLE
fix: correct docker cp source path so WildFly redeploys all WARs

### DIFF
--- a/start-picsure.sh
+++ b/start-picsure.sh
@@ -166,7 +166,10 @@ docker run --name=wildfly --restart always --network=picsure --network=hpds --ne
   || exit 2
 # Workaround for macOS bind-mount limitations: macOS does not support atomic file moves on mounted volumes,
 # causing "Device or resource busy" errors during hot deployments. We just copy the files into the running container.
-docker cp "${DOCKER_CONFIG_DIR}/wildfly/deployments/." "wildfly:/opt/jboss/wildfly/standalone/deployments/"
+# This refreshes ALL deployed WARs (pic-sure-api plus any aggregate/visualization resource WARs) from the shared
+# deployments dir. docker cp reads its source from the Jenkins (current) filesystem, so it MUST use
+# CURRENT_FS_DOCKER_CONFIG_DIR -- $DOCKER_CONFIG_DIR is the host path and does not exist inside this container.
+docker cp "${CURRENT_FS_DOCKER_CONFIG_DIR}/wildfly/deployments/." "wildfly:/opt/jboss/wildfly/standalone/deployments/"
 
 if $INCLUDE_UPLOADER; then
   docker compose --profile production -f $CURRENT_FS_DOCKER_CONFIG_DIR/uploader/docker-compose.yml up -d


### PR DESCRIPTION
## Problem

After **Check For Updates** + **Start PIC-SURE**, WildFly kept serving stale WARs — e.g. the old `@RolesAllowed("SUPER_ADMIN")` even though the rebuilt image carried the new role.

## Root cause

`start-picsure.sh` recreates the WildFly container and then copies the shared `wildfly/deployments` directory into it. `docker cp` reads its **source** from the Jenkins (client) filesystem, but the script used `${DOCKER_CONFIG_DIR}` — the *host* path (e.g. `/Users/.../local-all-in-one`), which does not exist inside the Jenkins container. So the copy failed silently every run (no `|| exit`), and WildFly was left serving whatever the `wildfly_deployments` volume already held, ignoring freshly built WARs.

## Fix

Use `${CURRENT_FS_DOCKER_CONFIG_DIR}` (`/usr/local/docker-config`, the in-container mount) as the `docker cp` source — matching where the **PIC-SURE-API**, **Aggregate Resource**, and **Visualization** build jobs all write their WARs. Because the whole directory is copied, this refreshes `pic-sure-api` **and every aggregate/visualization resource WAR** into WildFly on each Start PIC-SURE.

The named `wildfly_deployments` volume is intentionally **kept** — it is the persistent shared deployments dir for all WARs, and it keeps WildFly's runtime marker-file writes off the macOS bind mount (the reason #205 introduced it).

## Verification

A/B test of the `docker cp` run inside the Jenkins container:

| cp source | result |
|---|---|
| `${DOCKER_CONFIG_DIR}` (old) | `lstat /Users…: no such file or directory` — copy fails |
| `${CURRENT_FS_DOCKER_CONFIG_DIR}` (this fix) | delivers `pic-sure-api-2.war` **and** a dummy `verify-resource.war` into the container |

`bash -n start-picsure.sh` passes.
