### PR TITLE
WIP: Phase 3 (AIO) — gateway deploy poll + health wiring

### DIFF
--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Database Migrations/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Database Migrations/config.xml
@@ -89,7 +89,7 @@ node {
         //git url: &apos;https://github.com/hms-dbmi/pic-sure&apos;
         docker.image(&apos;dbmi/pic-sure-db-migrations:pic-sure-db-migration_v1.0&apos;).inside(&apos;--network=picsure -v $DOCKER_CONFIG_DIR/flyway/picsure:/opt/flyway-migrations/picsure &quot;--entrypoint=&quot; &apos;) {
             sh &quot;rm -rf /opt/flyway-migrations/picsure/sql&quot;
-            sh &quot;cp -R ./pic-sure-api-data/src/main/resources/db/sql /opt/flyway-migrations/picsure/sql&quot;
+            sh &quot;cp -R ./pic-sure-legacy/pic-sure-api-data/src/main/resources/db/sql /opt/flyway-migrations/picsure/sql&quot;
             sh &quot;/opt/flyway/flyway -X -configFiles=/opt/flyway-migrations/picsure/flyway-picsure.conf migrate&quot;
             sleep(time:1,unit:&quot;SECONDS&quot;)
         }

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Gateway Build and Deploy/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Gateway Build and Deploy/config.xml
@@ -16,7 +16,7 @@
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>git_hash</name>
-          <defaultValue>origin/pic_sure_api_rewrite</defaultValue>
+          <defaultValue>pic_sure_api_rewrite_p3</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Gateway Build and Deploy/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/PIC-SURE Gateway Build and Deploy/config.xml
@@ -91,7 +91,7 @@ docker run --name=gateway --restart always --network=picsure \
 
 # Step 4: smoke -- poll the gateway&apos;s own health endpoint from inside the network
 for i in $(seq 1 12); do
-  if docker run --rm --network=picsure busybox wget -qO- http://gateway:8080/actuator/health &gt;/dev/null 2&gt;&amp;1; then
+  if docker run --rm --network=picsure busybox wget -qO- http://gateway:8080/actuator/health/liveness &gt;/dev/null 2&gt;&amp;1; then
     echo &quot;Gateway is healthy.&quot;
     exit 0
   fi


### PR DESCRIPTION
**WIP / draft** — Phase 3 AIO changes. Stacked per design spec §9.
**Base:** `pic_sure_api_rewrite` (AIO integration; includes the layout-aware PSA build-job fix so the WAR builds on the monorepo branch).
**In this PR:** gateway deploy smoke-poll uses `/actuator/health/liveness` (downstream-independent) so a degraded sibling can't fail a gateway deploy once the Phase-3 health list is wired.
