### PR TITLE
Monitoring stack (M1+M5): Prometheus/Grafana, dashboards, Jenkins lifecycle

### DIFF
--- a/initial-configuration/config/httpd/httpd-vhosts-ssloffload.conf
+++ b/initial-configuration/config/httpd/httpd-vhosts-ssloffload.conf
@@ -56,3 +56,16 @@ Listen 0.0.0.0:80
     TransferLog "${HTTPD_PREFIX}/logs/access_log"
 
 </VirtualHost>
+
+# --- monitoring: mod_status for apache-exporter (port 8081 is container-internal only) ---
+<IfModule !status_module>
+LoadModule status_module modules/mod_status.so
+</IfModule>
+Listen 8081
+ExtendedStatus On
+<VirtualHost *:8081>
+    <Location "/server-status">
+        SetHandler server-status
+        Require all granted
+    </Location>
+</VirtualHost>

--- a/initial-configuration/config/httpd/httpd-vhosts.conf
+++ b/initial-configuration/config/httpd/httpd-vhosts.conf
@@ -129,3 +129,16 @@ ServerTokens Prod
          nokeepalive ssl-unclean-shutdown \
          downgrade-1.0 force-response-1.0
 </VirtualHost>
+
+# --- monitoring: mod_status for apache-exporter (port 8081 is container-internal only) ---
+<IfModule !status_module>
+LoadModule status_module modules/mod_status.so
+</IfModule>
+Listen 8081
+ExtendedStatus On
+<VirtualHost *:8081>
+    <Location "/server-status">
+        SetHandler server-status
+        Require all granted
+    </Location>
+</VirtualHost>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Start Monitoring/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Start Monitoring/config.xml
@@ -1,0 +1,24 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Starts only the monitoring stack (Prometheus/Grafana/exporters) for the all-in-one deployment, without touching app containers. Requires the opt-in $DOCKER_CONFIG_DIR/monitoring/ directory with monitoring.env populated (see monitoring/README.md &quot;Setup (opt-in)&quot;) -- monitoring/start-monitoring.sh exits 1 with an explanatory error if it is missing. Safe to re-run: it re-syncs the monitoring/ config (docker-compose, prometheus rules, grafana dashboards, blackbox config) into $DOCKER_CONFIG_DIR/monitoring/ and restarts the prometheus container automatically when config changed. Start PIC-SURE / Stop PIC-SURE already start/stop this stack implicitly via the same opt-in check; this job exists for monitoring-only cycling (e.g. dashboard rollouts) without cycling the rest of the platform.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>
+export CURRENT_FS_DOCKER_CONFIG_DIR=/usr/local/docker-config/
+bash monitoring/start-monitoring.sh
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Start Monitoring/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Start Monitoring/config.xml
@@ -15,7 +15,7 @@
     <hudson.tasks.Shell>
       <command>
 export CURRENT_FS_DOCKER_CONFIG_DIR=/usr/local/docker-config/
-bash monitoring/start-monitoring.sh
+bash /scripts/monitoring/start-monitoring.sh
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Stop Monitoring/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Stop Monitoring/config.xml
@@ -15,7 +15,7 @@
     <hudson.tasks.Shell>
       <command>
 export CURRENT_FS_DOCKER_CONFIG_DIR=/usr/local/docker-config/
-bash monitoring/stop-monitoring.sh
+bash /scripts/monitoring/stop-monitoring.sh
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Stop Monitoring/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Stop Monitoring/config.xml
@@ -1,0 +1,24 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Stops only the monitoring stack (Prometheus/Grafana/exporters) for the all-in-one deployment, without touching app containers. Exits cleanly (0) when monitoring was never installed -- monitoring/stop-monitoring.sh checks for $DOCKER_CONFIG_DIR/monitoring/docker-compose.monitoring.yml first and just prints &quot;monitoring not installed; nothing to stop&quot; otherwise. Does not touch the Prometheus/Grafana data volumes (TSDB history and Grafana state persist across stop/start cycles). Start PIC-SURE / Stop PIC-SURE already start/stop this stack implicitly via the same opt-in check; this job exists for monitoring-only cycling without touching the rest of the platform.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>
+export CURRENT_FS_DOCKER_CONFIG_DIR=/usr/local/docker-config/
+bash monitoring/stop-monitoring.sh
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -51,8 +51,12 @@ that block into `$DOCKER_CONFIG_DIR/httpd/httpd-vhosts.conf` yourself and run
 
 Two dedicated jobs — `Start Monitoring` and `Stop Monitoring`
 (`initial-configuration/jenkins/jenkins-docker/jobs/`) run
-`monitoring/start-monitoring.sh` / `monitoring/stop-monitoring.sh` directly,
+`/scripts/monitoring/start-monitoring.sh` / `/scripts/monitoring/stop-monitoring.sh`,
 mirroring the existing `Start PIC-SURE` / `Stop PIC-SURE` job conventions.
+The Jenkins container mounts this repo's `monitoring/` directory at
+`/scripts/monitoring` (see `start-jenkins.sh`), so a Jenkins container restart
+via `stop-jenkins.sh`/`start-jenkins.sh` is required after pulling this change
+for the mount to take effect.
 Load them into a running Jenkins instance with:
 
 ```bash

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -35,6 +35,15 @@ monitoring stack up automatically (and `stop-picsure.sh` tears it down). You
 can also manage it directly with `bash monitoring/start-monitoring.sh` /
 `bash monitoring/stop-monitoring.sh`.
 
+### Existing deployments (upgrading)
+
+The mod_status block that apache-exporter scrapes (the `# --- monitoring:`
+block at the end of this repo's `initial-configuration/config/httpd/httpd-vhosts.conf`)
+is only copied into `$DOCKER_CONFIG_DIR/httpd/httpd-vhosts.conf` at install
+time. On a deployment that was installed before this block existed, re-sync
+that block into `$DOCKER_CONFIG_DIR/httpd/httpd-vhosts.conf` yourself and run
+`docker restart httpd` — otherwise the `apache` Prometheus target stays down.
+
 ## Known issues
 
 - **macOS / Docker Desktop:** node-exporter's `/:/host:ro,rslave` mount fails
@@ -43,6 +52,9 @@ can also manage it directly with `bash monitoring/start-monitoring.sh` /
   mount`). This is expected on macOS; the rest of the stack works normally,
   and the `node` Prometheus target simply shows as down. Node metrics work
   correctly on Linux hosts (e.g., EC2 all-in-one deployments).
+  `start-monitoring.sh` tolerates this automatically — it brings up the other
+  services strictly and only warns if node-exporter fails — so
+  `start-picsure.sh` / `start-monitoring.sh` still exit 0 on macOS.
 
 ## Access
 
@@ -60,8 +72,10 @@ in this repo (not from Grafana's UI-saved state). The loop is:
 1. Edit a dashboard JSON file in this repo.
 2. Run `bash monitoring/start-monitoring.sh` — it re-syncs the repo's
    `docker-compose.monitoring.yml`, `prometheus/`, and `grafana/` assets into
-   `$DOCKER_CONFIG_DIR/monitoring/` (never touching your `monitoring.env` or
-   secrets) and re-runs `docker compose up -d`.
+   `$DOCKER_CONFIG_DIR/monitoring/` (it regenerates the Prometheus app-token
+   secret from `monitoring.env` each run, but never edits `monitoring.env`
+   itself), re-runs `docker compose up -d`, and restarts the Prometheus
+   container automatically so any config/rule changes take effect.
 3. Restart the Grafana container so it reloads the provisioned dashboards:
    `docker restart grafana`.
 
@@ -70,8 +84,9 @@ in this repo (not from Grafana's UI-saved state). The loop is:
 `monitoring/prometheus/prometheus-aio.yml` has one scrape job commented out
 per service (hpds, dictionary, psama, visualization, logging, query-ops).
 As each service gains a `/actuator/prometheus` (or equivalent) endpoint,
-uncomment its job block, redeploy with `start-monitoring.sh`, and confirm it
-shows up as `up` in Prometheus targets.
+uncomment its job block, redeploy with `start-monitoring.sh` (which restarts
+Prometheus automatically so the new scrape config takes effect), and confirm
+it shows up as `up` in Prometheus targets.
 
 ## BDC / FISMA notes
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -35,6 +35,15 @@ monitoring stack up automatically (and `stop-picsure.sh` tears it down). You
 can also manage it directly with `bash monitoring/start-monitoring.sh` /
 `bash monitoring/stop-monitoring.sh`.
 
+## Known issues
+
+- **macOS / Docker Desktop:** node-exporter's `/:/host:ro,rslave` mount fails
+  to start due to VirtioFS mount-propagation limits in Docker Desktop (error:
+  `path /host_mnt is mounted on /host_mnt but it is not a shared or slave
+  mount`). This is expected on macOS; the rest of the stack works normally,
+  and the `node` Prometheus target simply shows as down. Node metrics work
+  correctly on Linux hosts (e.g., EC2 all-in-one deployments).
+
 ## Access
 
 Grafana is reachable only at `http://127.0.0.1:3001` (never published on a

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -47,6 +47,24 @@ time. On a deployment that was installed before this block existed, re-sync
 that block into `$DOCKER_CONFIG_DIR/httpd/httpd-vhosts.conf` yourself and run
 `docker restart httpd` — otherwise the `apache` Prometheus target stays down.
 
+## Jenkins
+
+Two dedicated jobs — `Start Monitoring` and `Stop Monitoring`
+(`initial-configuration/jenkins/jenkins-docker/jobs/`) run
+`monitoring/start-monitoring.sh` / `monitoring/stop-monitoring.sh` directly,
+mirroring the existing `Start PIC-SURE` / `Stop PIC-SURE` job conventions.
+Load them into a running Jenkins instance with:
+
+```bash
+./update-jenkins.sh --jobs-only
+```
+
+The existing `Start PIC-SURE` / `Stop PIC-SURE` jobs already start and stop
+the monitoring stack implicitly via the same `$DOCKER_CONFIG_DIR/monitoring/`
+opt-in check described above — the dedicated jobs exist for monitoring-only
+cycling (e.g. redeploying a dashboard change) without restarting the rest of
+the platform.
+
 ## Known issues
 
 - **macOS / Docker Desktop:** node-exporter's `/:/host:ro,rslave` mount fails

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,91 @@
+# PIC-SURE Monitoring Stack
+
+This directory holds the opt-in Prometheus + Grafana observability stack for the
+all-in-one (AIO) deployment: Prometheus v3.4.1, Grafana 11.6.0 (bound to
+`127.0.0.1:3001` only), node-exporter (host/container metrics), cadvisor
+(container metrics), and an apache-exporter reading httpd's `mod_status`
+endpoint. It scrapes Prometheus itself, the gateway's `/actuator/prometheus`
+(token-gated), node-exporter, cadvisor, and apache-exporter today; further
+per-service jobs are pre-written but commented out until those services expose
+metrics (see "M2 activation" below). Design rationale, architecture, and the
+full rollout plan live in the pic-sure repo at
+`docs/superpowers/specs/2026-07-06-monitoring-stack-design.md`.
+
+## Setup (opt-in)
+
+The stack is off by default. `start-picsure.sh` / `stop-picsure.sh` only start
+or stop it if `$DOCKER_CONFIG_DIR/monitoring/` exists. To opt in:
+
+```bash
+mkdir "$DOCKER_CONFIG_DIR/monitoring"
+cp monitoring/monitoring.env.example "$DOCKER_CONFIG_DIR/monitoring/monitoring.env"
+```
+
+Edit `$DOCKER_CONFIG_DIR/monitoring/monitoring.env` and fill in both values:
+
+- `PICSURE_APPLICATION_TOKEN` — must match the value already set in
+  `$DOCKER_CONFIG_DIR/gateway/gateway.env`. This is the same
+  `X-Application-Token` the gateway's actuator endpoint requires; Prometheus
+  writes it to a secrets file (`$DOCKER_CONFIG_DIR/monitoring/secrets/app-token`)
+  and sends it as a request header when scraping.
+- `GF_SECURITY_ADMIN_PASSWORD` — the Grafana admin password (see Access below).
+
+Once `monitoring.env` exists, the next `start-picsure.sh` run brings the
+monitoring stack up automatically (and `stop-picsure.sh` tears it down). You
+can also manage it directly with `bash monitoring/start-monitoring.sh` /
+`bash monitoring/stop-monitoring.sh`.
+
+## Access
+
+Grafana is reachable only at `http://127.0.0.1:3001` (never published on a
+wide interface). Log in as user `admin` with the password you set as
+`GF_SECURITY_ADMIN_PASSWORD`. Prometheus has no published host port; it's
+reachable only from other containers on the `monitoring` network at
+`prometheus:9090`.
+
+## Editing dashboards
+
+Dashboards are provisioned from JSON files in `monitoring/grafana/dashboards/`
+in this repo (not from Grafana's UI-saved state). The loop is:
+
+1. Edit a dashboard JSON file in this repo.
+2. Run `bash monitoring/start-monitoring.sh` — it re-syncs the repo's
+   `docker-compose.monitoring.yml`, `prometheus/`, and `grafana/` assets into
+   `$DOCKER_CONFIG_DIR/monitoring/` (never touching your `monitoring.env` or
+   secrets) and re-runs `docker compose up -d`.
+3. Restart the Grafana container so it reloads the provisioned dashboards:
+   `docker restart grafana`.
+
+## M2 activation
+
+`monitoring/prometheus/prometheus-aio.yml` has one scrape job commented out
+per service (hpds, dictionary, psama, visualization, logging, query-ops).
+As each service gains a `/actuator/prometheus` (or equivalent) endpoint,
+uncomment its job block, redeploy with `start-monitoring.sh`, and confirm it
+shows up as `up` in Prometheus targets.
+
+## BDC / FISMA notes
+
+`monitoring/prometheus/prometheus-bdc.yml` in this repo is a template with
+`__REGION__` / `__ENVIRONMENT_NAME__` placeholders; it is not deployed
+directly from here. It gets rendered (placeholders substituted) by
+`deploy-monitoring.sh` in the `pic-sure-bdc-infrastructure` repo, which also
+provisions the EC2-SD-based Prometheus/Grafana instance in AWS. Grafana there
+is not publicly reachable — access it via an SSM port-forward, e.g.:
+
+```bash
+aws ssm start-session --target <monitoring-instance-id> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["3000"],"localPortNumber":["3001"]}'
+```
+
+then browse `http://127.0.0.1:3001` as usual.
+
+## Explicitly deferred (do not re-litigate; see spec §10)
+
+- Alerting: Grafana-native, starter rules (target down, error-rate spike, heap pressure, disk fill), notification channel — after baselines exist.
+- Custom domain metrics (HPDS query timers, cache hit rates, queue depths).
+- FISMA `/grafana/` httpd route — pending security review.
+- Tracing (OTel/Micrometer Tracing) — separate spec if wanted.
+- Legacy WildFly — never (retires with rewrite).
+- AIM-AHEAD monitoring parity — M3/M4 patterns apply; scheduled with the consolidation's dual-environment Phase 3 work.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -156,6 +156,24 @@ To opt in:
    GRANT pg_monitor TO monitoring;
    ```
 
+   **Statement-level metrics** (the "Top Statements"/"Mean Latency" panels on
+   the Databases dashboard): MySQL needs nothing extra — the exporter reads
+   `performance_schema` statement digests, which the grant above already
+   covers. PostgreSQL additionally needs `pg_stat_statements` loaded and the
+   extension created (as the superuser; persists in the data volume across
+   container recreations):
+
+   ```sql
+   ALTER SYSTEM SET shared_preload_libraries = 'pg_stat_statements';
+   -- restart the container, then:
+   CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+   ALTER SYSTEM SET pg_stat_statements.track = 'all';
+   SELECT pg_reload_conf();
+   ```
+
+   Without it, postgres-exporter's `--collector.stat_statements` simply
+   yields no `pg_stat_statements_*` series; everything else still works.
+
 2. Set the corresponding keys in `$DOCKER_CONFIG_DIR/monitoring/monitoring.env`
    (see `monitoring.env.example`): `MONITORING_MYSQL_USER` /
    `MONITORING_MYSQL_PASSWORD` for mysqld-exporter, `MONITORING_PG_USER` /

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -3,12 +3,15 @@
 This directory holds the opt-in Prometheus + Grafana observability stack for the
 all-in-one (AIO) deployment: Prometheus v3.4.1, Grafana 11.6.0 (bound to
 `127.0.0.1:3001` only), node-exporter (host/container metrics), cadvisor
-(container metrics), and an apache-exporter reading httpd's `mod_status`
-endpoint. It scrapes Prometheus itself, the gateway's `/actuator/prometheus`
-(token-gated), node-exporter, cadvisor, and apache-exporter today; further
-per-service jobs are pre-written but commented out until those services expose
-metrics (see "M2 activation" below). Design rationale, architecture, and the
-full rollout plan live in the pic-sure repo at
+(container metrics), an apache-exporter reading httpd's `mod_status`
+endpoint, and a blackbox-exporter for synthetic HTTP probes + TLS certificate
+expiry. It scrapes Prometheus itself, the gateway's `/actuator/prometheus`
+(token-gated), node-exporter, cadvisor, apache-exporter, and blackbox today;
+further per-service jobs are pre-written but commented out until those
+services expose metrics (see "M2 activation" below). Two DB exporters
+(postgres-exporter, mysqld-exporter) are also available but opt-in — see
+"DB exporters" below. Design rationale, architecture, and the full rollout
+plan live in the pic-sure repo at
 `docs/superpowers/specs/2026-07-06-monitoring-stack-design.md`.
 
 ## Setup (opt-in)
@@ -88,14 +91,75 @@ uncomment its job block, redeploy with `start-monitoring.sh` (which restarts
 Prometheus automatically so the new scrape config takes effect), and confirm
 it shows up as `up` in Prometheus targets.
 
+## M5: Synthetic probes & TLS certificate expiry
+
+blackbox-exporter (v0.26.0) probes a small set of HTTP(S) endpoints and
+exposes the results (up/down, latency, HTTP status, TLS certificate expiry)
+to Prometheus. In AIO it probes `https://httpd/picsure/health` and
+`https://httpd/` using the `http_2xx_insecure` module
+(`monitoring/blackbox/blackbox.yml`): httpd's cert is issued for the
+publicly-resolvable name, not the docker-internal `httpd` hostname, so
+strict TLS verification would always fail there even though the site is
+healthy — `insecure_skip_verify` is used only to avoid that false negative;
+`probe_ssl_earliest_cert_expiry` is still collected normally, so expiry
+alerts remain meaningful. Publicly-resolvable targets (FISMA ALB, staging —
+see BDC notes below) use the strict `http_2xx` module instead.
+
+The `PIC-SURE / Synthetics & Certificates` Grafana dashboard
+(`monitoring/grafana/dashboards/synthetics-certificates.json`) shows probe
+success, probe duration, HTTP status code, and days-to-certificate-expiry
+per target (red below 14 days, yellow below 30).
+
+## M5: DB exporters (opt-in)
+
+postgres-exporter (v0.16.0) and mysqld-exporter (v0.17.2) are defined in
+`docker-compose.monitoring.yml` under the `db-exporters` compose profile, so
+a plain `docker compose up -d` never starts them — they only come up when
+`start-monitoring.sh` finds matching credentials in `monitoring.env`.
+
+To opt in:
+
+1. Create a **read-only** monitoring user on each database you want metrics
+   from. MySQL (`picsure-db`):
+
+   ```sql
+   CREATE USER 'monitoring'@'%' IDENTIFIED BY '...';
+   GRANT PROCESS, REPLICATION CLIENT, SELECT ON performance_schema.* TO 'monitoring'@'%';
+   ```
+
+   PostgreSQL (`dictionary-db`, database `dictionary`):
+
+   ```sql
+   CREATE ROLE monitoring LOGIN PASSWORD '...';
+   GRANT pg_monitor TO monitoring;
+   ```
+
+2. Set the corresponding keys in `$DOCKER_CONFIG_DIR/monitoring/monitoring.env`
+   (see `monitoring.env.example`): `MONITORING_MYSQL_USER` /
+   `MONITORING_MYSQL_PASSWORD` for mysqld-exporter, `MONITORING_PG_USER` /
+   `MONITORING_PG_PASSWORD` for postgres-exporter. Leave a pair empty to skip
+   that exporter.
+3. Rerun `bash monitoring/start-monitoring.sh`. It writes
+   `$DOCKER_CONFIG_DIR/monitoring/secrets/db-exporters.env` (chmod 600) from
+   those keys and starts each exporter only if both of its keys are present;
+   otherwise it prints a one-line "skipping <exporter> (no MONITORING_*
+   credentials in monitoring.env)" and moves on.
+
+Once running, `postgres-exporter:9187` and `mysqld-exporter:9104` are scraped
+by the `postgres` / `mysql` Prometheus jobs (they show `down` until the
+profile is enabled) and surfaced on the `PIC-SURE / Databases` dashboard
+(`monitoring/grafana/dashboards/databases.json`), alongside the existing
+Micrometer JDBC pool metrics from the app side.
+
 ## BDC / FISMA notes
 
 `monitoring/prometheus/prometheus-bdc.yml` in this repo is a template with
-`__REGION__` / `__ENVIRONMENT_NAME__` placeholders; it is not deployed
-directly from here. It gets rendered (placeholders substituted) by
-`deploy-monitoring.sh` in the `pic-sure-bdc-infrastructure` repo, which also
-provisions the EC2-SD-based Prometheus/Grafana instance in AWS. Grafana there
-is not publicly reachable — access it via an SSM port-forward, e.g.:
+`__REGION__` / `__ENVIRONMENT_NAME__` / `__PUBLIC_DNS__` / `__STAGING_DNS__`
+placeholders; it is not deployed directly from here. It gets rendered
+(placeholders substituted) by `deploy-monitoring.sh` in the
+`pic-sure-bdc-infrastructure` repo, which also provisions the EC2-SD-based
+Prometheus/Grafana instance in AWS. Grafana there is not publicly
+reachable — access it via an SSM port-forward, e.g.:
 
 ```bash
 aws ssm start-session --target <monitoring-instance-id> \
@@ -104,6 +168,16 @@ aws ssm start-session --target <monitoring-instance-id> \
 ```
 
 then browse `http://127.0.0.1:3001` as usual.
+
+`monitoring/grafana/provisioning-bdc/` and `monitoring/grafana/dashboards-bdc/`
+are **FISMA-only** assets (a CloudWatch datasource and an AWS Edge dashboard
+for ALB/RDS/EBS metrics) — they are installed by `deploy-monitoring.sh` in
+the BDC repo, not by this repo's `start-monitoring.sh`, which only ever
+syncs `grafana/provisioning` and `grafana/dashboards`. The `prometheus-bdc.yml`
+mysql job scrapes `mysqld-exporter:9104` directly (no compose profile there —
+BDC's podman-based deploy wires it unconditionally); there is intentionally
+no `postgres` job in that file yet — see the stub comment in
+`prometheus-bdc.yml` for why.
 
 ## Explicitly deferred (do not re-litigate; see spec §10)
 

--- a/monitoring/blackbox/blackbox.yml
+++ b/monitoring/blackbox/blackbox.yml
@@ -1,0 +1,15 @@
+modules:
+  http_2xx:            # strict TLS — use for publicly-resolvable names (FISMA ALB, staging)
+    prober: http
+    timeout: 10s
+    http:
+      preferred_ip_protocol: ip4
+      follow_redirects: true
+  http_2xx_insecure:   # docker-internal names (cert CN won't match) — expiry metrics still collected
+    prober: http
+    timeout: 10s
+    http:
+      preferred_ip_protocol: ip4
+      follow_redirects: true
+      tls_config:
+        insecure_skip_verify: true

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,86 @@
+# PIC-SURE monitoring stack (AIO). Runtime home: $DOCKER_CONFIG_DIR/monitoring/
+# (start-monitoring.sh syncs this directory there and runs compose from it).
+# Spec: pic-sure docs/superpowers/specs/2026-07-06-monitoring-stack-design.md
+name: picsure-monitoring
+
+services:
+  prometheus:
+    image: prom/prometheus:v3.4.1
+    container_name: prometheus
+    restart: always
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+      - --storage.tsdb.path=/prometheus
+    volumes:
+      - ./prometheus/prometheus-aio.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/rules:/etc/prometheus/rules:ro
+      - ./secrets:/etc/prometheus/secrets:ro
+      - prometheus-data:/prometheus
+    networks:
+      - monitoring
+      - picsure
+      - dictionary   # dictionary-dump is reachable only on this internal network
+
+  grafana:
+    image: grafana/grafana:11.6.0
+    container_name: grafana
+    restart: always
+    env_file:
+      - ./monitoring.env   # GF_SECURITY_ADMIN_PASSWORD
+    environment:
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    ports:
+      - "127.0.0.1:3001:3000"   # localhost only; never published wide
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    networks:
+      - monitoring
+
+  node-exporter:
+    image: prom/node-exporter:v1.9.1
+    container_name: node-exporter
+    restart: always
+    pid: host
+    command:
+      - --path.rootfs=/host
+    volumes:
+      - /:/host:ro,rslave
+    networks:
+      - monitoring
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    container_name: cadvisor
+    restart: always
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - monitoring
+
+  apache-exporter:
+    image: lusotycoon/apache-exporter:v1.0.10
+    container_name: apache-exporter
+    restart: always
+    command:
+      - --scrape_uri=http://httpd:8081/server-status?auto
+    networks:
+      - monitoring
+      - picsure
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  monitoring:
+  picsure:
+    external: true
+  dictionary:
+    external: true

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -93,6 +93,9 @@ services:
     container_name: postgres-exporter
     restart: always
     profiles: ["db-exporters"]
+    command:
+      # statement-level metrics; requires pg_stat_statements preloaded on the DB (see README)
+      - --collector.stat_statements
     env_file: ./secrets/db-exporters.env
     networks:
       - monitoring
@@ -106,6 +109,8 @@ services:
     command:
       - --mysqld.username=${MONITORING_MYSQL_USER:-monitoring}
       - --mysqld.address=picsure-db:3306
+      # statement-digest metrics from performance_schema (monitoring user has SELECT there)
+      - --collect.perf_schema.eventsstatements
     env_file: ./secrets/db-exporters.env
     networks:
       - monitoring

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -74,6 +74,43 @@ services:
       - monitoring
       - picsure
 
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.26.0
+    container_name: blackbox-exporter
+    restart: always
+    command:
+      - --config.file=/etc/blackbox/blackbox.yml
+    volumes:
+      - ./blackbox:/etc/blackbox:ro
+    networks:
+      - monitoring
+      - picsure   # must reach httpd
+
+  # --- Opt-in DB exporters (profile db-exporters; started only when
+  # MONITORING_* credentials are present in monitoring.env — see start-monitoring.sh) ---
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.16.0
+    container_name: postgres-exporter
+    restart: always
+    profiles: ["db-exporters"]
+    env_file: ./secrets/db-exporters.env
+    networks:
+      - monitoring
+      - dictionary
+
+  mysqld-exporter:
+    image: prom/mysqld-exporter:v0.17.2
+    container_name: mysqld-exporter
+    restart: always
+    profiles: ["db-exporters"]
+    command:
+      - --mysqld.username=${MONITORING_MYSQL_USER:-monitoring}
+      - --mysqld.address=picsure-db:3306
+    env_file: ./secrets/db-exporters.env
+    networks:
+      - monitoring
+      - picsure
+
 volumes:
   prometheus-data:
   grafana-data:

--- a/monitoring/grafana/dashboards-bdc/aws-edge.json
+++ b/monitoring/grafana/dashboards-bdc/aws-edge.json
@@ -1,0 +1,200 @@
+{
+  "uid": "picsure-aws-edge",
+  "title": "PIC-SURE / AWS Edge (BDC)",
+  "schemaVersion": 39,
+  "refresh": "1m",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["picsure", "bdc"],
+  "templating": {
+    "list": [
+      {
+        "name": "loadbalancer",
+        "label": "Load Balancer",
+        "type": "query",
+        "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+        "query": "dimension_values(us-east-1,AWS/ApplicationELB,RequestCount,LoadBalancer)",
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "current": {}
+      },
+      {
+        "name": "dbinstance",
+        "label": "RDS Instance",
+        "type": "query",
+        "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+        "query": "dimension_values(us-east-1,AWS/RDS,CPUUtilization,DBInstanceIdentifier)",
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "current": {}
+      },
+      {
+        "name": "volumeid",
+        "label": "EBS Volume",
+        "type": "query",
+        "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+        "query": "dimension_values(us-east-1,AWS/EBS,BurstBalance,VolumeId)",
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "ALB Request Count",
+      "type": "timeseries",
+      "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+          "region": "us-east-1",
+          "namespace": "AWS/ApplicationELB",
+          "metricName": "RequestCount",
+          "statistic": "Sum",
+          "dimensions": { "LoadBalancer": "$loadbalancer" }
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "ALB 5XX Count",
+      "type": "timeseries",
+      "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+          "region": "us-east-1",
+          "namespace": "AWS/ApplicationELB",
+          "metricName": "HTTPCode_ELB_5XX_Count",
+          "statistic": "Sum",
+          "dimensions": { "LoadBalancer": "$loadbalancer" }
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "ALB Target Response Time (p95)",
+      "type": "timeseries",
+      "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+          "region": "us-east-1",
+          "namespace": "AWS/ApplicationELB",
+          "metricName": "TargetResponseTime",
+          "statistic": "p95",
+          "dimensions": { "LoadBalancer": "$loadbalancer" }
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "ALB Healthy Host Count",
+      "type": "timeseries",
+      "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+          "region": "us-east-1",
+          "namespace": "AWS/ApplicationELB",
+          "metricName": "HealthyHostCount",
+          "statistic": "Minimum",
+          "dimensions": { "LoadBalancer": "$loadbalancer" }
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "RDS CPU Utilization",
+      "type": "timeseries",
+      "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "percent" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+          "region": "us-east-1",
+          "namespace": "AWS/RDS",
+          "metricName": "CPUUtilization",
+          "statistic": "Average",
+          "dimensions": { "DBInstanceIdentifier": "$dbinstance" }
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "RDS Database Connections",
+      "type": "timeseries",
+      "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+          "region": "us-east-1",
+          "namespace": "AWS/RDS",
+          "metricName": "DatabaseConnections",
+          "statistic": "Average",
+          "dimensions": { "DBInstanceIdentifier": "$dbinstance" }
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "RDS Free Storage Space",
+      "type": "timeseries",
+      "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+          "region": "us-east-1",
+          "namespace": "AWS/RDS",
+          "metricName": "FreeStorageSpace",
+          "statistic": "Average",
+          "dimensions": { "DBInstanceIdentifier": "$dbinstance" }
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "EBS Burst Balance",
+      "type": "timeseries",
+      "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "percent" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "cloudwatch", "uid": "picsure-cloudwatch" },
+          "region": "us-east-1",
+          "namespace": "AWS/EBS",
+          "metricName": "BurstBalance",
+          "statistic": "Average",
+          "dimensions": { "VolumeId": "$volumeid" }
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/databases.json
+++ b/monitoring/grafana/dashboards/databases.json
@@ -1,0 +1,118 @@
+{
+  "uid": "picsure-databases",
+  "title": "PIC-SURE / Databases",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["picsure"],
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "PG Connections",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (state) (pg_stat_activity_count)",
+          "legendFormat": "{{state}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "pg_settings_max_connections",
+          "legendFormat": "max_connections"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "MySQL Threads Connected",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "mysql_global_status_threads_connected",
+          "legendFormat": "connected"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "mysql_global_variables_max_connections",
+          "legendFormat": "max_connections"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "PG Deadlocks / Rollbacks",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "rate(pg_stat_database_xact_rollback[5m])",
+          "legendFormat": "{{datname}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "MySQL Slow Queries",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "rate(mysql_global_status_slow_queries[5m])"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "MySQL Buffer Pool Utilization",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "mysql_global_status_innodb_buffer_pool_bytes_data / mysql_global_variables_innodb_buffer_pool_size"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "App JDBC Pool — Active Connections",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (application) (hikaricp_connections_active)",
+          "legendFormat": "{{application}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/databases.json
+++ b/monitoring/grafana/dashboards/databases.json
@@ -3,28 +3,52 @@
   "title": "PIC-SURE / Databases",
   "schemaVersion": 39,
   "refresh": "30s",
-  "time": { "from": "now-3h", "to": "now" },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
   "timezone": "browser",
-  "tags": ["picsure"],
-  "templating": { "list": [] },
+  "tags": [
+    "picsure"
+  ],
+  "templating": {
+    "list": []
+  },
   "panels": [
     {
       "id": 1,
       "title": "PG Connections",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
-      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "sum by (state) (pg_stat_activity_count)",
           "legendFormat": "{{state}}"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "pg_settings_max_connections",
           "legendFormat": "max_connections"
         }
@@ -34,19 +58,36 @@
       "id": 2,
       "title": "MySQL Threads Connected",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
-      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "mysql_global_status_threads_connected",
           "legendFormat": "connected"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "mysql_global_variables_max_connections",
           "legendFormat": "max_connections"
         }
@@ -56,13 +97,27 @@
       "id": 3,
       "title": "PG Deadlocks / Rollbacks",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
-      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "rate(pg_stat_database_xact_rollback[5m])",
           "legendFormat": "{{datname}}"
         }
@@ -72,13 +127,27 @@
       "id": 4,
       "title": "MySQL Slow Queries",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
-      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "rate(mysql_global_status_slow_queries[5m])"
         }
       ]
@@ -87,13 +156,29 @@
       "id": 5,
       "title": "MySQL Buffer Pool Utilization",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
-      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "mysql_global_status_innodb_buffer_pool_bytes_data / mysql_global_variables_innodb_buffer_pool_size"
         }
       ]
@@ -102,15 +187,141 @@
       "id": 6,
       "title": "App JDBC Pool — Active Connections",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
-      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "sum by (application) (hikaricp_connections_active)",
           "legendFormat": "{{application}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "MySQL Top Statements — DB Time Rate",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(mysql_perf_schema_events_statements_seconds_total[5m]))",
+          "legendFormat": "{{schema}}: {{digest_text}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "MySQL Statement Mean Latency",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(mysql_perf_schema_events_statements_seconds_total[5m]) / rate(mysql_perf_schema_events_statements_total[5m]) > 0)",
+          "legendFormat": "{{schema}}: {{digest_text}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "PG Top Statements — DB Time Rate (dictionary)",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(pg_stat_statements_seconds_total[5m]))",
+          "legendFormat": "queryid {{queryid}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "PG Statement Mean Latency (dictionary)",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(pg_stat_statements_seconds_total[5m]) / rate(pg_stat_statements_calls_total[5m]) > 0)",
+          "legendFormat": "queryid {{queryid}}"
         }
       ]
     }

--- a/monitoring/grafana/dashboards/http-detail.json
+++ b/monitoring/grafana/dashboards/http-detail.json
@@ -1,0 +1,98 @@
+{
+  "uid": "picsure-http",
+  "title": "PIC-SURE / HTTP Detail",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["picsure"],
+  "templating": {
+    "list": [
+      {
+        "name": "application",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+        "query": "label_values(http_server_requests_seconds_count, application)",
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate by Route",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{application=\"$application\"}[5m]))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Error Rate by Status",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (status) (rate(http_server_requests_seconds_count{application=\"$application\", status!~\"2..\"}[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "p50/p95/p99",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"$application\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"$application\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"$application\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Slowest Routes (p95)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "topk(10, histogram_quantile(0.95, sum by (uri, le) (rate(http_server_requests_seconds_bucket{application=\"$application\"}[5m]))))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/infrastructure.json
+++ b/monitoring/grafana/dashboards/infrastructure.json
@@ -1,0 +1,129 @@
+{
+  "uid": "picsure-infra",
+  "title": "PIC-SURE / Infrastructure",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["picsure"],
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Host CPU",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Host Memory",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Disk Used",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"})",
+          "legendFormat": "{{instance}} {{mountpoint}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Container CPU",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (name) (rate(container_cpu_usage_seconds_total{name!=\"\"}[5m]))",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Container Memory",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "container_memory_working_set_bytes{name!=\"\"}",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Apache Requests /s",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "rate(apache_accesses_total[5m])"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Apache Busy/Idle Workers",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 16 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "apache_workers{state=\"busy\"}",
+          "legendFormat": "busy"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "apache_workers{state=\"idle\"}",
+          "legendFormat": "idle"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/jvm-detail.json
+++ b/monitoring/grafana/dashboards/jvm-detail.json
@@ -1,0 +1,105 @@
+{
+  "uid": "picsure-jvm",
+  "title": "PIC-SURE / JVM Detail",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["picsure"],
+  "templating": {
+    "list": [
+      {
+        "name": "application",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+        "query": "label_values(jvm_memory_used_bytes, application)",
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Heap Used vs Max",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (id) (jvm_memory_used_bytes{application=\"$application\", area=\"heap\"})",
+          "legendFormat": "{{id}} used"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (id) (jvm_memory_max_bytes{application=\"$application\", area=\"heap\"})",
+          "legendFormat": "{{id}} max"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "GC Pause Time /s",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (action, cause) (rate(jvm_gc_pause_seconds_sum{application=\"$application\"}[5m]))",
+          "legendFormat": "{{action}} {{cause}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Live Threads",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "jvm_threads_live_threads{application=\"$application\"}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Process CPU",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 8, "x": 8, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "process_cpu_usage{application=\"$application\"}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Loaded Classes",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 9 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "jvm_classes_loaded_classes{application=\"$application\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/platform-overview.json
+++ b/monitoring/grafana/dashboards/platform-overview.json
@@ -1,0 +1,135 @@
+{
+  "uid": "picsure-overview",
+  "title": "PIC-SURE / Platform Overview",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["picsure"],
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Targets Down",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "count(up == 0) OR vector(0)"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Target Status",
+      "type": "table",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 5, "w": 20, "x": 4, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "up",
+          "instant": true,
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Request Rate by Service",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "picsure:http_requests:rate5m",
+          "legendFormat": "{{application}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "5xx Error Rate by Service",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "picsure:http_errors:rate5m",
+          "legendFormat": "{{application}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "p95 Latency by Service",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 14 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "picsure:http_latency_p95:5m",
+          "legendFormat": "{{application}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Host CPU",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 6, "x": 12, "y": 14 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Host Memory Used",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 6, "x": 18, "y": 14 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/query-path.json
+++ b/monitoring/grafana/dashboards/query-path.json
@@ -1,0 +1,76 @@
+{
+  "uid": "picsure-query-path",
+  "title": "PIC-SURE / Query Path",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["picsure"],
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Gateway Route Rate",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{application=\"pic-sure-gateway\"}[5m]))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Gateway p95 by Route",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "histogram_quantile(0.95, sum by (uri, le) (rate(http_server_requests_seconds_bucket{application=\"pic-sure-gateway\"}[5m])))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Downstream Client p95 (per host)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "histogram_quantile(0.95, sum by (client_name, le) (rate(http_client_requests_seconds_bucket[5m])))",
+          "legendFormat": "{{client_name}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Downstream Client Errors",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "sum by (client_name, status) (rate(http_client_requests_seconds_count{outcome!=\"SUCCESS\"}[5m]))",
+          "legendFormat": "{{client_name}} {{status}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/query-path.json
+++ b/monitoring/grafana/dashboards/query-path.json
@@ -3,22 +3,43 @@
   "title": "PIC-SURE / Query Path",
   "schemaVersion": 39,
   "refresh": "30s",
-  "time": { "from": "now-3h", "to": "now" },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
   "timezone": "browser",
-  "tags": ["picsure"],
-  "templating": { "list": [] },
+  "tags": [
+    "picsure"
+  ],
+  "templating": {
+    "list": []
+  },
   "panels": [
     {
       "id": 1,
       "title": "Gateway Route Rate",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
-      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "sum by (uri) (rate(http_server_requests_seconds_count{application=\"pic-sure-gateway\"}[5m]))",
           "legendFormat": "{{uri}}"
         }
@@ -28,13 +49,29 @@
       "id": 2,
       "title": "Gateway p95 by Route",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "histogram_quantile(0.95, sum by (uri, le) (rate(http_server_requests_seconds_bucket{application=\"pic-sure-gateway\"}[5m])))",
           "legendFormat": "{{uri}}"
         }
@@ -42,31 +79,64 @@
     },
     {
       "id": 3,
-      "title": "Downstream Client p95 (per host)",
+      "title": "Downstream Client Mean Latency",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-          "expr": "histogram_quantile(0.95, sum by (client_name, le) (rate(http_client_requests_seconds_bucket[5m])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
+          "expr": "sum by (client_name) (rate(http_client_requests_seconds_sum[5m])) / sum by (client_name) (rate(http_client_requests_seconds_count[5m]))",
           "legendFormat": "{{client_name}}"
         }
-      ]
+      ],
+      "description": "Mean latency of the gateway's calls per downstream. p95 requires client-side percentile histograms — enable with the M2 instrumentation standard."
     },
     {
       "id": 4,
       "title": "Downstream Client Errors",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
-      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "picsure-prom"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "No client errors in range"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "picsure-prom"
+          },
           "expr": "sum by (client_name, status) (rate(http_client_requests_seconds_count{outcome!=\"SUCCESS\"}[5m]))",
           "legendFormat": "{{client_name}} {{status}}"
         }

--- a/monitoring/grafana/dashboards/synthetics-certificates.json
+++ b/monitoring/grafana/dashboards/synthetics-certificates.json
@@ -1,0 +1,100 @@
+{
+  "uid": "picsure-synthetics",
+  "title": "PIC-SURE / Synthetics & Certificates",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["picsure"],
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Probe Success",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "probe_success",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Days to Certificate Expiry",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 14 },
+              { "color": "green", "value": 30 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "(probe_ssl_earliest_cert_expiry - time()) / 86400",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Probe Duration",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "probe_duration_seconds",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "HTTP Status Code",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "picsure-prom" },
+          "expr": "probe_http_status_code",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning-bdc/datasources/cloudwatch.yml
+++ b/monitoring/grafana/provisioning-bdc/datasources/cloudwatch.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: CloudWatch
+    uid: picsure-cloudwatch
+    type: cloudwatch
+    jsonData:
+      authType: default
+      defaultRegion: us-east-1
+    editable: false

--- a/monitoring/grafana/provisioning/dashboards/picsure.yml
+++ b/monitoring/grafana/provisioning/dashboards/picsure.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: picsure
+    folder: PIC-SURE
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: picsure-prom
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/monitoring.env.example
+++ b/monitoring/monitoring.env.example
@@ -5,3 +5,12 @@
 PICSURE_APPLICATION_TOKEN=
 # Grafana admin password (user: admin), http://127.0.0.1:3001
 GF_SECURITY_ADMIN_PASSWORD=
+
+# --- Opt-in DB exporters (M5) ---
+# Read-only monitoring DB users. Leave all four empty to skip DB exporters
+# entirely (mysqld-exporter/postgres-exporter simply won't start). See
+# README.md "DB exporters" for the SQL to create these users.
+MONITORING_MYSQL_USER=
+MONITORING_MYSQL_PASSWORD=
+MONITORING_PG_USER=
+MONITORING_PG_PASSWORD=

--- a/monitoring/monitoring.env.example
+++ b/monitoring/monitoring.env.example
@@ -1,0 +1,6 @@
+# Copy to $DOCKER_CONFIG_DIR/monitoring/monitoring.env and fill in.
+# PICSURE_APPLICATION_TOKEN must equal the value in gateway.env (and each
+# instrumented service's env) — it is the X-Application-Token actuator gate.
+PICSURE_APPLICATION_TOKEN=
+# Grafana admin password (user: admin), http://127.0.0.1:3001
+GF_SECURITY_ADMIN_PASSWORD=

--- a/monitoring/monitoring.env.example
+++ b/monitoring/monitoring.env.example
@@ -1,6 +1,7 @@
 # Copy to $DOCKER_CONFIG_DIR/monitoring/monitoring.env and fill in.
 # PICSURE_APPLICATION_TOKEN must equal the value in gateway.env (and each
 # instrumented service's env) — it is the X-Application-Token actuator gate.
+# Values are used verbatim: no surrounding quotes, no spaces around `=`.
 PICSURE_APPLICATION_TOKEN=
 # Grafana admin password (user: admin), http://127.0.0.1:3001
 GF_SECURITY_ADMIN_PASSWORD=

--- a/monitoring/prometheus/prometheus-aio.yml
+++ b/monitoring/prometheus/prometheus-aio.yml
@@ -78,3 +78,28 @@ scrape_configs:
   - job_name: apache
     static_configs:
       - targets: ["apache-exporter:9117"]
+
+  - job_name: blackbox
+    metrics_path: /probe
+    params:
+      module: [http_2xx_insecure]
+    static_configs:
+      - targets: ["https://httpd/picsure/health", "https://httpd/"]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
+  # postgres/mysql targets show `down` until the db-exporters compose profile
+  # is enabled (MONITORING_* credentials set in monitoring.env) — mirrors the
+  # documented opt-in flow in README.md.
+  - job_name: postgres
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  - job_name: mysql
+    static_configs:
+      - targets: ["mysqld-exporter:9104"]

--- a/monitoring/prometheus/prometheus-aio.yml
+++ b/monitoring/prometheus/prometheus-aio.yml
@@ -1,0 +1,80 @@
+# AIO scrape config. Only services that expose /actuator/prometheus TODAY are
+# active; M2 targets are pre-written but commented (spec §4/§8).
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    env: aio
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: gateway
+    metrics_path: /actuator/prometheus
+    http_headers:
+      X-Application-Token:
+        files:
+          - /etc/prometheus/secrets/app-token
+    static_configs:
+      - targets: ["gateway:8080"]
+
+  # --- M2 targets: uncomment per service as it gains micrometer-prometheus ---
+  # - job_name: hpds
+  #   metrics_path: /actuator/prometheus
+  #   http_headers:
+  #     X-Application-Token:
+  #       files: [/etc/prometheus/secrets/app-token]
+  #   static_configs:
+  #     - targets: ["hpds:8080"]
+  # - job_name: dictionary
+  #   metrics_path: /actuator/prometheus
+  #   http_headers:
+  #     X-Application-Token:
+  #       files: [/etc/prometheus/secrets/app-token]
+  #   static_configs:
+  #     - targets: ["dictionary-api:80", "dictionary-dump:80"]
+  # - job_name: psama
+  #   metrics_path: /auth/actuator/prometheus
+  #   http_headers:
+  #     X-Application-Token:
+  #       files: [/etc/prometheus/secrets/app-token]
+  #   static_configs:
+  #     - targets: ["psama:8090"]
+  # - job_name: visualization
+  #   metrics_path: /actuator/prometheus
+  #   http_headers:
+  #     X-Application-Token:
+  #       files: [/etc/prometheus/secrets/app-token]
+  #   static_configs:
+  #     - targets: ["visualization:8080"]   # verify 8080-vs-80 (spec §4)
+  # - job_name: logging
+  #   metrics_path: /metrics
+  #   http_headers:
+  #     X-Application-Token:
+  #       files: [/etc/prometheus/secrets/app-token]
+  #   static_configs:
+  #     - targets: ["pic-sure-logging:8080"]
+  # - job_name: query-ops           # once start-picsure.sh runs these containers
+  #   metrics_path: /actuator/prometheus
+  #   http_headers:
+  #     X-Application-Token:
+  #       files: [/etc/prometheus/secrets/app-token]
+  #   static_configs:
+  #     - targets: ["pic-sure-hpds-query-service:8080", "pic-sure-operations-service:8080"]
+
+  - job_name: node
+    static_configs:
+      - targets: ["node-exporter:9100"]
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["cadvisor:8080"]
+
+  - job_name: apache
+    static_configs:
+      - targets: ["apache-exporter:9117"]

--- a/monitoring/prometheus/prometheus-aio.yml
+++ b/monitoring/prometheus/prometheus-aio.yml
@@ -59,13 +59,14 @@ scrape_configs:
   #       files: [/etc/prometheus/secrets/app-token]
   #   static_configs:
   #     - targets: ["pic-sure-logging:8080"]
-  # - job_name: query-ops           # once start-picsure.sh runs these containers
-  #   metrics_path: /actuator/prometheus
-  #   http_headers:
-  #     X-Application-Token:
-  #       files: [/etc/prometheus/secrets/app-token]
-  #   static_configs:
-  #     - targets: ["pic-sure-hpds-query-service:8080", "pic-sure-operations-service:8080"]
+  # Active since start-picsure.sh manages these containers (rewrite lifecycle commit 4edcffe)
+  - job_name: query-ops
+    metrics_path: /actuator/prometheus
+    http_headers:
+      X-Application-Token:
+        files: [/etc/prometheus/secrets/app-token]
+    static_configs:
+      - targets: ["pic-sure-hpds-query-service:8080", "pic-sure-operations-service:8080"]
 
   - job_name: node
     static_configs:

--- a/monitoring/prometheus/prometheus-aio.yml
+++ b/monitoring/prometheus/prometheus-aio.yml
@@ -21,7 +21,10 @@ scrape_configs:
         files:
           - /etc/prometheus/secrets/app-token
     static_configs:
+      # application label stamped here until services set management.metrics.tags.application (M2)
       - targets: ["gateway:8080"]
+        labels:
+          application: pic-sure-gateway
 
   # --- M2 targets: uncomment per service as it gains micrometer-prometheus ---
   # - job_name: hpds
@@ -68,6 +71,8 @@ scrape_configs:
         files: [/etc/prometheus/secrets/app-token]
     static_configs:
       - targets: ["pic-sure-hpds-query-service:8080"]
+        labels:
+          application: pic-sure-hpds-query-service
   - job_name: operations-service
     metrics_path: /operations/actuator/prometheus
     http_headers:
@@ -75,6 +80,8 @@ scrape_configs:
         files: [/etc/prometheus/secrets/app-token]
     static_configs:
       - targets: ["pic-sure-operations-service:8080"]
+        labels:
+          application: pic-sure-operations-service
 
   - job_name: node
     static_configs:

--- a/monitoring/prometheus/prometheus-aio.yml
+++ b/monitoring/prometheus/prometheus-aio.yml
@@ -59,14 +59,22 @@ scrape_configs:
   #       files: [/etc/prometheus/secrets/app-token]
   #   static_configs:
   #     - targets: ["pic-sure-logging:8080"]
-  # Active since start-picsure.sh manages these containers (rewrite lifecycle commit 4edcffe)
-  - job_name: query-ops
+  # Active since start-picsure.sh manages these containers (rewrite lifecycle commit 4edcffe).
+  # Split into two jobs: operations-service serves under context path /operations.
+  - job_name: query-service
     metrics_path: /actuator/prometheus
     http_headers:
       X-Application-Token:
         files: [/etc/prometheus/secrets/app-token]
     static_configs:
-      - targets: ["pic-sure-hpds-query-service:8080", "pic-sure-operations-service:8080"]
+      - targets: ["pic-sure-hpds-query-service:8080"]
+  - job_name: operations-service
+    metrics_path: /operations/actuator/prometheus
+    http_headers:
+      X-Application-Token:
+        files: [/etc/prometheus/secrets/app-token]
+    static_configs:
+      - targets: ["pic-sure-operations-service:8080"]
 
   - job_name: node
     static_configs:

--- a/monitoring/prometheus/prometheus-bdc.yml
+++ b/monitoring/prometheus/prometheus-bdc.yml
@@ -1,0 +1,65 @@
+# BDC/FISMA scrape config — rendered by deploy-monitoring.sh (sed on __TOKENS__).
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    env: bdc
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: node
+    ec2_sd_configs:
+      - region: __REGION__
+        port: 9100
+        filters:
+          - name: tag:Environment
+            values: ["__ENVIRONMENT_NAME__"]
+          - name: instance-state-name
+            values: ["running"]
+    relabel_configs: &ec2_relabel
+      - source_labels: [__meta_ec2_tag_Node]
+        target_label: role
+      - source_labels: [__meta_ec2_tag_Stack]
+        target_label: stack
+      - source_labels: [__meta_ec2_private_ip]
+        target_label: host_ip
+
+  - job_name: podman
+    ec2_sd_configs:
+      - region: __REGION__
+        port: 9882
+        filters:
+          - name: tag:Environment
+            values: ["__ENVIRONMENT_NAME__"]
+          - name: instance-state-name
+            values: ["running"]
+    relabel_configs: *ec2_relabel
+
+  - job_name: apache
+    ec2_sd_configs:
+      - region: __REGION__
+        port: 9117
+        filters:
+          - name: tag:Environment
+            values: ["__ENVIRONMENT_NAME__"]
+          - name: tag:Node
+            values: ["HTTPD"]
+          - name: instance-state-name
+            values: ["running"]
+    relabel_configs: *ec2_relabel
+
+  # --- M4 app targets (enable after consolidation Phase 3; spec §6.2/§8) ---
+  # wildfly host services on private-IP-bound publishes:
+  #   dictionary 9401 (/actuator/prometheus), logging 9402 (/metrics),
+  #   visualization 9403 (/actuator/prometheus), psama 9404 (/auth/actuator/prometheus)
+  # hpds hosts: 8080 (/actuator/prometheus), filter tag:Node values [HPDS, OPEN_HPDS]
+  # All with:
+  #   http_headers:
+  #     X-Application-Token:
+  #       files: [/etc/prometheus/secrets/app-token]

--- a/monitoring/prometheus/prometheus-bdc.yml
+++ b/monitoring/prometheus/prometheus-bdc.yml
@@ -63,3 +63,28 @@ scrape_configs:
   #   http_headers:
   #     X-Application-Token:
   #       files: [/etc/prometheus/secrets/app-token]
+
+  - job_name: blackbox
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets: ["https://__PUBLIC_DNS__/picsure/health", "https://__STAGING_DNS__/picsure/health"]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
+  - job_name: mysql
+    static_configs:
+      - targets: ["mysqld-exporter:9104"]
+
+  # --- FISMA dictionary-PG stub: postgres_exporter is intentionally NOT wired
+  # here. The dictionary-PG endpoint is not in this repo — it lives only in
+  # the S3-managed `configs/picsure-dictionary/picsure-dictionary.env`
+  # (see aio README.md "DB exporters"). Once that endpoint is known, add a
+  # `postgres` job here targeting `postgres-exporter:9187` on the podman
+  # `monitoring` network, same pattern as the mysql job above.

--- a/monitoring/prometheus/rules/picsure-recording.yml
+++ b/monitoring/prometheus/rules/picsure-recording.yml
@@ -1,0 +1,9 @@
+groups:
+  - name: picsure-http
+    rules:
+      - record: picsure:http_requests:rate5m
+        expr: sum by (env, application) (rate(http_server_requests_seconds_count[5m]))
+      - record: picsure:http_errors:rate5m
+        expr: sum by (env, application) (rate(http_server_requests_seconds_count{status=~"5.."}[5m]))
+      - record: picsure:http_latency_p95:5m
+        expr: histogram_quantile(0.95, sum by (env, application, le) (rate(http_server_requests_seconds_bucket[5m])))

--- a/monitoring/prometheus/rules/picsure-recording.yml
+++ b/monitoring/prometheus/rules/picsure-recording.yml
@@ -2,8 +2,8 @@ groups:
   - name: picsure-http
     rules:
       - record: picsure:http_requests:rate5m
-        expr: sum by (env, application) (rate(http_server_requests_seconds_count[5m]))
+        expr: sum by (application) (rate(http_server_requests_seconds_count[5m]))
       - record: picsure:http_errors:rate5m
-        expr: sum by (env, application) (rate(http_server_requests_seconds_count{status=~"5.."}[5m]))
+        expr: sum by (application) (rate(http_server_requests_seconds_count{status=~"5.."}[5m]))
       - record: picsure:http_latency_p95:5m
-        expr: histogram_quantile(0.95, sum by (env, application, le) (rate(http_server_requests_seconds_bucket[5m])))
+        expr: histogram_quantile(0.95, sum by (application, le) (rate(http_server_requests_seconds_bucket[5m])))

--- a/monitoring/start-monitoring.sh
+++ b/monitoring/start-monitoring.sh
@@ -14,6 +14,13 @@ if [[ ! -f "$MON_DIR/monitoring.env" ]]; then
   exit 1
 fi
 
+# Remember whether prometheus was already running *before* we sync new config,
+# so we know afterwards whether it needs restarting to pick up the changes.
+PROMETHEUS_WAS_RUNNING=false
+if [[ "$(docker inspect -f '{{.State.Running}}' prometheus 2>/dev/null)" == "true" ]]; then
+  PROMETHEUS_WAS_RUNNING=true
+fi
+
 # Sync repo assets (never the user's env/secrets/data)
 mkdir -p "$MON_DIR/prometheus/rules" "$MON_DIR/grafana" "$MON_DIR/secrets"
 cp "$SCRIPT_DIR/docker-compose.monitoring.yml" "$MON_DIR/"
@@ -21,14 +28,31 @@ cp "$SCRIPT_DIR/prometheus/prometheus-aio.yml" "$MON_DIR/prometheus/"
 cp "$SCRIPT_DIR/prometheus/rules/"*.yml "$MON_DIR/prometheus/rules/"
 cp -R "$SCRIPT_DIR/grafana/provisioning" "$SCRIPT_DIR/grafana/dashboards" "$MON_DIR/grafana/"
 
-# Token secret file for Prometheus http_headers
-# shellcheck disable=SC1091
-source "$MON_DIR/monitoring.env"
+# Token secret file for Prometheus http_headers.
+# Extract just the one key we need instead of sourcing the whole env file, so a
+# stray value in monitoring.env can't execute shell code.
+PICSURE_APPLICATION_TOKEN="$(grep -E '^PICSURE_APPLICATION_TOKEN=' "$MON_DIR/monitoring.env" | head -1 | cut -d= -f2-)"
 if [[ -z "${PICSURE_APPLICATION_TOKEN:-}" ]]; then
   echo "WARNING: PICSURE_APPLICATION_TOKEN is empty in monitoring.env; token-gated scrapes will 401." >&2
 fi
 printf '%s' "${PICSURE_APPLICATION_TOKEN:-}" > "$MON_DIR/secrets/app-token"
 chmod 600 "$MON_DIR/secrets/app-token"
 
-docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" up -d
+# Bring up the core services strictly. node-exporter's `/:/host:ro,rslave`
+# mount fails at container-create on macOS Docker Desktop (VirtioFS
+# mount-propagation limits) — tolerate only that one service failing so the
+# rest of the platform start doesn't get killed by `set -euo pipefail`
+# (see README Known issues).
+docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" up -d prometheus grafana cadvisor apache-exporter
+docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" up -d node-exporter \
+  || echo "WARNING: node-exporter failed to start (expected on macOS Docker Desktop — see README Known issues); continuing without host metrics"
+
+# `docker compose up -d` won't recreate a container just because a bind-mounted
+# file's content changed, and this Prometheus has no reload endpoint enabled.
+# If it was already running, restart it now so the freshly-synced
+# prometheus.yml / rules take effect; a fresh create already picks them up.
+if [[ "$PROMETHEUS_WAS_RUNNING" == true ]]; then
+  docker restart prometheus >/dev/null
+fi
+
 echo "Monitoring up. Grafana: http://127.0.0.1:3001  Prometheus (inside network): prometheus:9090"

--- a/monitoring/start-monitoring.sh
+++ b/monitoring/start-monitoring.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Sync monitoring assets into $DOCKER_CONFIG_DIR/monitoring and start the stack.
+# Opt-in: create $DOCKER_CONFIG_DIR/monitoring/ with a monitoring.env in it
+# (see monitoring.env.example). start-picsure.sh calls this when that dir exists.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_CONFIG_DIR="${DOCKER_CONFIG_DIR:-/usr/local/docker-config}"
+CURRENT_FS_DOCKER_CONFIG_DIR="${CURRENT_FS_DOCKER_CONFIG_DIR:-$DOCKER_CONFIG_DIR}"
+MON_DIR="$CURRENT_FS_DOCKER_CONFIG_DIR/monitoring"
+
+if [[ ! -f "$MON_DIR/monitoring.env" ]]; then
+  echo "ERROR: $MON_DIR/monitoring.env not found. Copy monitoring.env.example there and fill it in." >&2
+  exit 1
+fi
+
+# Sync repo assets (never the user's env/secrets/data)
+mkdir -p "$MON_DIR/prometheus/rules" "$MON_DIR/grafana" "$MON_DIR/secrets"
+cp "$SCRIPT_DIR/docker-compose.monitoring.yml" "$MON_DIR/"
+cp "$SCRIPT_DIR/prometheus/prometheus-aio.yml" "$MON_DIR/prometheus/"
+cp "$SCRIPT_DIR/prometheus/rules/"*.yml "$MON_DIR/prometheus/rules/"
+cp -R "$SCRIPT_DIR/grafana/provisioning" "$SCRIPT_DIR/grafana/dashboards" "$MON_DIR/grafana/"
+
+# Token secret file for Prometheus http_headers
+# shellcheck disable=SC1091
+source "$MON_DIR/monitoring.env"
+if [[ -z "${PICSURE_APPLICATION_TOKEN:-}" ]]; then
+  echo "WARNING: PICSURE_APPLICATION_TOKEN is empty in monitoring.env; token-gated scrapes will 401." >&2
+fi
+printf '%s' "${PICSURE_APPLICATION_TOKEN:-}" > "$MON_DIR/secrets/app-token"
+chmod 600 "$MON_DIR/secrets/app-token"
+
+docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" up -d
+echo "Monitoring up. Grafana: http://127.0.0.1:3001  Prometheus (inside network): prometheus:9090"

--- a/monitoring/start-monitoring.sh
+++ b/monitoring/start-monitoring.sh
@@ -22,11 +22,12 @@ if [[ "$(docker inspect -f '{{.State.Running}}' prometheus 2>/dev/null)" == "tru
 fi
 
 # Sync repo assets (never the user's env/secrets/data)
-mkdir -p "$MON_DIR/prometheus/rules" "$MON_DIR/grafana" "$MON_DIR/secrets"
+mkdir -p "$MON_DIR/prometheus/rules" "$MON_DIR/grafana" "$MON_DIR/secrets" "$MON_DIR/blackbox"
 cp "$SCRIPT_DIR/docker-compose.monitoring.yml" "$MON_DIR/"
 cp "$SCRIPT_DIR/prometheus/prometheus-aio.yml" "$MON_DIR/prometheus/"
 cp "$SCRIPT_DIR/prometheus/rules/"*.yml "$MON_DIR/prometheus/rules/"
 cp -R "$SCRIPT_DIR/grafana/provisioning" "$SCRIPT_DIR/grafana/dashboards" "$MON_DIR/grafana/"
+cp "$SCRIPT_DIR/blackbox/blackbox.yml" "$MON_DIR/blackbox/"
 
 # Token secret file for Prometheus http_headers.
 # Extract just the one key we need instead of sourcing the whole env file, so a
@@ -38,14 +39,53 @@ fi
 printf '%s' "${PICSURE_APPLICATION_TOKEN:-}" > "$MON_DIR/secrets/app-token"
 chmod 600 "$MON_DIR/secrets/app-token"
 
+# Opt-in DB exporter credentials (db-exporters profile). Same grep-extraction
+# pattern as the app token above: pull only the keys we need out of
+# monitoring.env rather than sourcing it. Absent/empty keys mean "don't start
+# that exporter" — checked after `up -d` below. These four keys are new
+# (M5) and optional, so — unlike PICSURE_APPLICATION_TOKEN, which every
+# monitoring.env is required to have — grep may legitimately find no match
+# on an older monitoring.env; `|| true` keeps that from tripping `pipefail`.
+MONITORING_MYSQL_USER="$(grep -E '^MONITORING_MYSQL_USER=' "$MON_DIR/monitoring.env" | head -1 | cut -d= -f2- || true)"
+MONITORING_MYSQL_PASSWORD="$(grep -E '^MONITORING_MYSQL_PASSWORD=' "$MON_DIR/monitoring.env" | head -1 | cut -d= -f2- || true)"
+MONITORING_PG_USER="$(grep -E '^MONITORING_PG_USER=' "$MON_DIR/monitoring.env" | head -1 | cut -d= -f2- || true)"
+MONITORING_PG_PASSWORD="$(grep -E '^MONITORING_PG_PASSWORD=' "$MON_DIR/monitoring.env" | head -1 | cut -d= -f2- || true)"
+# mysqld-exporter's compose `command:` interpolates ${MONITORING_MYSQL_USER:-monitoring}
+# at `docker compose` invocation time (not from env_file, which only sets the
+# container's runtime environment) — export so that substitution sees it.
+export MONITORING_MYSQL_USER
+{
+  echo "DATA_SOURCE_NAME=postgresql://${MONITORING_PG_USER}:${MONITORING_PG_PASSWORD}@dictionary-db:5432/dictionary?sslmode=disable"
+  echo "MYSQLD_EXPORTER_PASSWORD=${MONITORING_MYSQL_PASSWORD}"
+  echo "MONITORING_MYSQL_USER=${MONITORING_MYSQL_USER}"
+} > "$MON_DIR/secrets/db-exporters.env"
+chmod 600 "$MON_DIR/secrets/db-exporters.env"
+
 # Bring up the core services strictly. node-exporter's `/:/host:ro,rslave`
 # mount fails at container-create on macOS Docker Desktop (VirtioFS
 # mount-propagation limits) — tolerate only that one service failing so the
 # rest of the platform start doesn't get killed by `set -euo pipefail`
 # (see README Known issues).
-docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" up -d prometheus grafana cadvisor apache-exporter
+docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" up -d prometheus grafana cadvisor apache-exporter blackbox-exporter
 docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" up -d node-exporter \
   || echo "WARNING: node-exporter failed to start (expected on macOS Docker Desktop — see README Known issues); continuing without host metrics"
+
+# Opt-in DB exporters (profile db-exporters, so a plain `up -d` above never
+# starts them). Each one only comes up if both of its credential keys are
+# present in monitoring.env — see README "DB exporters" for how to create the
+# read-only monitoring users.
+if [[ -n "$MONITORING_MYSQL_USER" && -n "$MONITORING_MYSQL_PASSWORD" ]]; then
+  docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" --profile db-exporters up -d mysqld-exporter \
+    || echo "WARNING: mysqld-exporter failed to start"
+else
+  echo "skipping mysqld-exporter (no MONITORING_MYSQL_* credentials in monitoring.env)"
+fi
+if [[ -n "$MONITORING_PG_USER" && -n "$MONITORING_PG_PASSWORD" ]]; then
+  docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" --profile db-exporters up -d postgres-exporter \
+    || echo "WARNING: postgres-exporter failed to start"
+else
+  echo "skipping postgres-exporter (no MONITORING_PG_* credentials in monitoring.env)"
+fi
 
 # `docker compose up -d` won't recreate a container just because a bind-mounted
 # file's content changed, and this Prometheus has no reload endpoint enabled.

--- a/monitoring/stop-monitoring.sh
+++ b/monitoring/stop-monitoring.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DOCKER_CONFIG_DIR="${DOCKER_CONFIG_DIR:-/usr/local/docker-config}"
+CURRENT_FS_DOCKER_CONFIG_DIR="${CURRENT_FS_DOCKER_CONFIG_DIR:-$DOCKER_CONFIG_DIR}"
+MON_DIR="$CURRENT_FS_DOCKER_CONFIG_DIR/monitoring"
+[[ -f "$MON_DIR/docker-compose.monitoring.yml" ]] || { echo "monitoring not installed; nothing to stop"; exit 0; }
+docker compose -f "$MON_DIR/docker-compose.monitoring.yml" --project-directory "$MON_DIR" down

--- a/start-jenkins.sh
+++ b/start-jenkins.sh
@@ -19,6 +19,7 @@ docker run -d \
   -v "$DOCKER_CONFIG_DIR":/usr/local/docker-config \
   -v ./start-picsure.sh:/scripts/start-picsure.sh \
   -v ./stop-picsure.sh:/scripts/stop-picsure.sh \
+  -v ./monitoring:/scripts/monitoring \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$MYSQL_CONFIG_DIR"/.my.cnf:/root/.my.cnf \
   -v "$HOME"/.m2:/root/.m2 \

--- a/start-picsure.sh
+++ b/start-picsure.sh
@@ -36,6 +36,8 @@ echo "INCLUDE_GATEWAY=$INCLUDE_GATEWAY"
 echo "INCLUDE_OPERATIONS=$INCLUDE_OPERATIONS"
 [[ -d "$CURRENT_FS_DOCKER_CONFIG_DIR/query" ]] && INCLUDE_QUERY=true || INCLUDE_QUERY=false
 echo "INCLUDE_QUERY=$INCLUDE_QUERY"
+[[ -d "$CURRENT_FS_DOCKER_CONFIG_DIR/monitoring" ]] && INCLUDE_MONITORING=true || INCLUDE_MONITORING=false
+echo "INCLUDE_MONITORING=$INCLUDE_MONITORING"
 
 # Docker Volumes
 export PICSURE_BANNER_VOLUME="-v $DOCKER_CONFIG_DIR/httpd/banner_config.json:/usr/local/apache2/htdocs/picsureui/settings/banner_config.json"
@@ -221,4 +223,8 @@ if $INCLUDE_VISUALIZATION; then
     $LOGGING_ENVS \
     -d hms-dbmi/pic-sure-visualization:LATEST \
     || exit 2
+fi
+
+if $INCLUDE_MONITORING; then
+  bash "$(dirname "${BASH_SOURCE[0]}")/monitoring/start-monitoring.sh"
 fi

--- a/start-picsure.sh
+++ b/start-picsure.sh
@@ -226,5 +226,7 @@ if $INCLUDE_VISUALIZATION; then
 fi
 
 if $INCLUDE_MONITORING; then
-  bash "$(dirname "${BASH_SOURCE[0]}")/monitoring/start-monitoring.sh"
+  MONITORING_SCRIPT="$(dirname "${BASH_SOURCE[0]}")/monitoring/start-monitoring.sh"
+  [[ -f "$MONITORING_SCRIPT" ]] || MONITORING_SCRIPT=/scripts/monitoring/start-monitoring.sh
+  bash "$MONITORING_SCRIPT"
 fi

--- a/stop-picsure.sh
+++ b/stop-picsure.sh
@@ -77,5 +77,7 @@ if $INCLUDE_OPERATIONS; then
 fi
 
 if $INCLUDE_MONITORING; then
-  bash "$(dirname "${BASH_SOURCE[0]}")/monitoring/stop-monitoring.sh"
+  MONITORING_SCRIPT="$(dirname "${BASH_SOURCE[0]}")/monitoring/stop-monitoring.sh"
+  [[ -f "$MONITORING_SCRIPT" ]] || MONITORING_SCRIPT=/scripts/monitoring/stop-monitoring.sh
+  bash "$MONITORING_SCRIPT"
 fi

--- a/stop-picsure.sh
+++ b/stop-picsure.sh
@@ -36,6 +36,8 @@ echo "INCLUDE_GATEWAY=$INCLUDE_GATEWAY"
 echo "INCLUDE_OPERATIONS=$INCLUDE_OPERATIONS"
 [[ -d "$CURRENT_FS_DOCKER_CONFIG_DIR/query" ]] && INCLUDE_QUERY=true || INCLUDE_QUERY=false
 echo "INCLUDE_QUERY=$INCLUDE_QUERY"
+[[ -d "$CURRENT_FS_DOCKER_CONFIG_DIR/monitoring" ]] && INCLUDE_MONITORING=true || INCLUDE_MONITORING=false
+echo "INCLUDE_MONITORING=$INCLUDE_MONITORING"
 
 if $INCLUDE_HPDS; then
   docker stop hpds && docker rm hpds
@@ -72,4 +74,8 @@ if $INCLUDE_QUERY; then
 fi
 if $INCLUDE_OPERATIONS; then
   docker stop pic-sure-operations-service && docker rm pic-sure-operations-service
+fi
+
+if $INCLUDE_MONITORING; then
+  bash "$(dirname "${BASH_SOURCE[0]}")/monitoring/stop-monitoring.sh"
 fi


### PR DESCRIPTION
Implements the aio side of the monitoring spec (M1 + M5). Spec: `docs/superpowers/specs/2026-07-06-monitoring-stack-design.md` (pic-sure repo, untracked by convention).

## What's included
- `monitoring/` — docker compose stack: Prometheus v3.4.1 (15d retention, joins `picsure`+`dictionary`), Grafana 11.6.0 (`127.0.0.1:3001` only), node-exporter, cAdvisor, apache-exporter, blackbox-exporter; opt-in postgres/mysqld exporters behind the `db-exporters` compose profile
- Scrape configs for both environments (`prometheus-aio.yml` active; `prometheus-bdc.yml` is the template rendered by pic-sure-bdc-infrastructure's `deploy-monitoring.sh`); M2 service jobs pre-staged as comments, gated on the consolidation
- 7 provisioned dashboards + FISMA-only assets (`grafana/provisioning-bdc/`, `dashboards-bdc/`) consumed by the FISMA deploy
- `INCLUDE_MONITORING` lifecycle hooks (config-dir convention) + `mod_status` listener on container-internal :8081
- Jenkins: `Start Monitoring`/`Stop Monitoring` jobs, `monitoring/` mounted into the Jenkins container, path fallback so the hook works under Jenkins
- Token-gated scrapes via the existing `X-Application-Token` / `PICSURE_APPLICATION_TOKEN` scheme (Prometheus `http_headers.files`)

## Verified
Live on a local aio stack: all active targets `up`, `probe_success==1` with cert-expiry metrics, Grafana healthy, `start-picsure.sh` exits 0 on macOS despite the documented node-exporter/Docker Desktop limitation.

## Review notes
- Base has advanced since the branch was cut (incl. actuator-off-by-default): aio must opt in via `PICSURE_ACTUATOR_EXPOSURE` or the gateway scrape target shows down — reconcile at merge
- Existing deployments must re-sync the vhosts `mod_status` block into `$DOCKER_CONFIG_DIR` (README "Existing deployments") and restart the Jenkins container to pick up the new mount
- DB exporters stay dormant until read-only monitoring DB users are provisioned (`monitoring.env.example`)